### PR TITLE
Update with JuliaCon 2015 dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             </div>
         </div>
         <div class="container intro-container">
+            <p><strong>SAVE THE DATE: JuliaCon 2015 will be held at the MIT Stata Center during the dates of Wednesday, June 24 through Sunday, June 28.  More details forthcoming.</strong></p>
             <p>Thank you for making the first-ever JuliaCon a smashing success! Recordings of the talks and discussion sessions are now up and linked to in the schedule below.</p>
             <strike><p>The first-ever <a href="http://www.julialang.org/">Julia</a> conference will take place <strong>June 26 and 27</strong> (Thursday and Friday) at the University of Chicago Gleacher Center in Chicago, Illinois. Expect two days of cutting-edge technical talks, a chance to rub shoulders with Julia's creators, and a weekend in a city known for its beautiful lakefront and world-class architecture.</p></strike>
         </div>


### PR DESCRIPTION
info taken from https://groups.google.com/forum/#!topic/julia-users/BCmUTgL0WSk

(Sadly I will be unable to attend, as the dates conflict with my honeymoon.  But I thought people visiting juliacon.org should know when the dates are. :)