### PR TITLE
RFC: adds the schedule currently in the master spreadsheet.

### DIFF
--- a/css/juliacon.css
+++ b/css/juliacon.css
@@ -516,6 +516,15 @@ td.time {
     width: 100px;
 }
 
+.schedule table {
+    white-space: nowrap;
+    margin-bottom: 20px;
+}
+
+.schedule .track-title {
+  font-weight: bold;
+}
+
 /* table { table-layout: fixed; } */
 
 /*------------------------------------

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@ title: JuliaCon
     historical significance and colonial architecture.
   </p>
   <p>
-    Submissions for talks are now closed, and the <a href="/sched.html">list of talks has been announced</a>. 
     <ul>
       <li>A <em>Regular</em> or <em>Student</em> ticket includes the talks on both Thursday and Friday.</li>
       <li>A <em>Workshops</em> ticket includes the workshops on both Wednesday and Saturday.</li>
@@ -34,6 +33,123 @@ title: JuliaCon
 
 </div>
 
+<div class="container schedule">
+  <div class="row"><h2 class="text-center border-header"><span>Schedule</span></h2></div>
+  <div class="row"><h3>Thursday, June 25</h3></div>
+  <table class="row">
+    <tr><td> 08:15 </td><td>  </td><td> Coffee and light breakfast </td></tr>
+    <tr><td> 08:45 </td><td>  </td><td> Opening Remarks            </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Scientific Applications I (Room 32-123)</span></div>
+  <table class="row schedule">
+    <tr><td> 09:00 </td><td> Daniel C. Jones </td><td> BioJulia: A modern bioinformatics framework                                       </td></tr>
+    <tr><td> 09:40 </td><td> Spencer Lyon    </td><td> Methods, Models, and Moments: Julian Economics with QuantEcon.jl                  </td></tr>
+    <tr><td> 10:20 </td><td> Kyle Barbary    </td><td> JuliaAstro                                                                        </td></tr>
+    <tr><td> 10:30 </td><td>                 </td><td> Break (30 Minutes)                                                                </td></tr>
+    <tr><td> 11:00 </td><td> Katharine Hyatt </td><td> Quantum Statistical Simulations with Julia                                        </td></tr>
+    <tr><td> 11:40 </td><td> David Beach     </td><td> Introducing Julia into a Python/C++ Scientific Computing Environment              </td></tr>
+    <tr><td> 11:50 </td><td> Simon Frost     </td><td> A case study of using MCMC in Julia: modeling hepatitis C dynamics during therapy </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 12:00 </td><td>  </td><td> Lunch </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Visualization and Interactivity (Room 32-123)</span></div>
+  <table class="row schedule">
+    <tr><td> 01:30 </td><td> Simon Danisch   </td><td> Hypersignals, a bold vision for interactive Data Visualization                           </td></tr>
+    <tr><td> 02:10 </td><td> Jack Minardi    </td><td> 3D Printing with Julia: Presenting "Euclid", a new high performance multimaterial slicer </td></tr>
+    <tr><td> 02:50 </td><td> Josef Heinen    </td><td> GR.jl - Plotting for Julia based on GR                                                   </td></tr>
+    <tr><td> 03:00 </td><td>                 </td><td> Break (20 Minutes)                                                                       </td></tr>
+    <tr><td> 03:20 </td><td> Mike Innes      </td><td> Apps in Julia                                                                            </td></tr>
+    <tr><td> 04:00 </td><td> Zachary Yedidia </td><td> SFML.jl -- A package for the Simple Fast Multimedia Library                              </td></tr>
+    <tr><td> 04:10 </td><td> Shashi Gowda    </td><td> Escher.jl: A new way to make and deploy GUIs                                             </td></tr>
+    <tr><td> 04:20 </td><td> Viral Shah      </td><td> JuliaBox - Julia in your browser                                                         </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Statistics (Room 32-141)</span></div>
+  <table class="row schedule">
+    <tr><td> 01:30 </td><td> Zenna Tavares    </td><td> Julia as a Probabilistic Programming Language                   </td></tr>
+    <tr><td> 02:10 </td><td> Chiyuan Zhang    </td><td> Mocha.jl - Deep Learning for Julia                              </td></tr>
+    <tr><td> 02:50 </td><td> Simon Kornblith  </td><td> L1 regularized regression                                       </td></tr>
+    <tr><td> 03:00 </td><td>                  </td><td> Break (20 Minutes)                                              </td></tr>
+    <tr><td> 03:20 </td><td> Pontus Stenetorp </td><td> Suitably Naming a Child with Multiple Nationalities using Julia </td></tr>
+    <tr><td> 04:00 </td><td> John Myles White </td><td> What needs to be done to move JuliaStats forward                </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 04:40 </td><td> </td><td> Break </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Ecosystem (Room 32-123)</span></div>
+  <table class="row schedule">
+    <tr><td> 5:00 </td><td> Tony Fong     </td><td> Lint.jl                                                                            </td></tr>
+    <tr><td> 5:40 </td><td> Tony Kelman   </td><td> How to support Windows: cross-platform installation and testing for Julia packages </td></tr>
+    <tr><td> 5:50 </td><td> Isaiah Norton </td><td> Automatic ccall wrapper generation with Clang.jl                                   </td></tr>
+    <tr><td> 6:00 </td><td> Iain Dunning  </td><td> Julia's Package Ecosystem: Past, Present, and Future                               </td></tr>
+    <tr><td> 6:10 </td><td> Leah Hanson   </td><td> Contributing to Julia                                                              </td></tr>
+    <tr><td> 6:20 </td><td>               </td><td> Discussion: Contributing &amp; Ecosystem                                           </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 07:00 </td><td> </td><td> Hang out with other Julians </td></tr>
+  </table>
+  <div class="row"><h3>Friday, June 26</h3></div>
+  <table class="row">
+    <tr><td> 08:15 </td><td>  </td><td> Coffee and light breakfast </td></tr>
+    <tr><td> 08:45 </td><td>  </td><td> Opening Remarks            </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Julia Internals (Room 32-123)</span></div>
+  <table class="row schedule">
+    <tr><td> 09:00 </td><td> Jeff Bezanson   </td><td> TBC (Invited)                                                                                                                        </td></tr>
+    <tr><td> 09:40 </td><td> Jake Bolewski   </td><td> TBC (Invited)                                                                                                                        </td></tr>
+    <tr><td> 10:20 </td><td> Westley Hennigh </td><td> Who optimizes the optimizers? Can genetic algorithms help us to<br>optimize the layout of llvm IR passes used to compile Julia code? </td></tr>
+    <tr><td> 10:30 </td><td>                 </td><td> Break (30 Minutes)                                                                                                                   </td></tr>
+    <tr><td> 11:00 </td><td> Keno Fischer    </td><td> TBC (Invited)                                                                                                                        </td></tr>
+    <tr><td> 11:40 </td><td> Isaiah Norton   </td><td> Automatic ccall wrapper generation with Clang.jl                                                                                     </td></tr>
+    <tr><td> 11:50 </td><td> Mauro Werder    </td><td> Traits.jl, interfaces for Julia                                                                                                      </td></tr>
+    <tr><td> 12:00 </td><td> Jacob Quinn     </td><td> What Happens When: From Parse-Time to Compile-Time                                                                                   </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 12:10 </td><td>  </td><td> Lunch </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Numerical Computing (Room 32-123)</span></div>
+  <table class="row schedule">
+    <tr><td> 01:30 </td><td> Jack Poulson     </td><td> Distributed-memory "direct" linear algebra and optimization </td></tr>
+    <tr><td> 02:10 </td><td> Zhang Xianyi     </td><td> Introduction to OpenBLAS and BLIS                           </td></tr>
+    <tr><td> 02:50 </td><td>                  </td><td> Break (20 Minutes)                                          </td></tr>
+    <tr><td> 03:10 </td><td> Viral B. Shah    </td><td> The present and future of sparse matrices in Julia.         </td></tr>
+    <tr><td> 03:50 </td><td> David P. Sanders </td><td> Validated numerics in Julia                                 </td></tr>
+    <tr><td> 04:00 </td><td> Luis Benet       </td><td> Taylor series expansions in julia                           </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Scientific Applications II (Room 32-141)</span></div>
+  <table class="row schedule">
+    <tr><td> 01:30 </td><td> Robert Moss                  </td><td> Using Julia as a Specification Language for the Next-Generation<br>Airborne Collision Avoidance System </td></tr>
+    <tr><td> 02:10 </td><td> Lars Ruthotto<br>Eldad Haber </td><td> Distributed Algorithms for Full-Waveform-Inversion (FWI)                                               </td></tr>
+    <tr><td> 02:50 </td><td>                              </td><td> Break (20 Minutes)                                                                                     </td></tr>
+    <tr><td> 03:10 </td><td> Iain Dunning                 </td><td> JuliaOpt: Optimization-related projects in Julia                                                       </td></tr>
+    <tr><td> 03:50 </td><td> Weijian Zhang                </td><td> Analyzing Evolving Graphs with Julia                                                                   </td></tr>
+    <tr><td> 04:00 </td><td> Blake Johnson                </td><td> Quickly building simulations of quantum systems                                                        </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 04:10 </td><td> </td><td> Break </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Data (Room 32-123)</span></div>
+  <table class="row schedule">
+    <tr><td> 04:30 </td><td> Simon Kornblith  </td><td> JLD: Saving Julia objects to the disk in HDF5 format                        </td></tr>
+    <tr><td> 05:10 </td><td> Avik Sengupta    </td><td> Serving up : A practical guide to exposing Julia APIs on the web            </td></tr>
+    <tr><td> 05:20 </td><td> Tanmay Mohapatra </td><td> ProtoBuf.jl - Interfacing Julia with Complex systems using Protocol Buffers </td></tr>
+    <tr><td> 05:30 </td><td> Eric Davies      </td><td> Towards A Consistent Database Interface                                     </td></tr>
+    <tr><td> 05:40 </td><td>                  </td><td> Discussion: Databases and Interchange                                       </td></tr>
+  </table>
+  <div class="row"><span class="track-title">Parallel Computing (Room 32-141)</span></div>
+  <table class="row schedule">
+    <tr><td> 04:30 </td><td> Amit Murthy                          </td><td> Cluster Managers and Parallel Julia </td></tr>
+    <tr><td> 05:10 </td><td> Kiran Pamnany<br>Ranjan Anantharaman </td><td> Multi-threading Julia               </td></tr>
+    <tr><td> 05:50 </td><td> Patrick Sanan                        </td><td> Using Julia on a Cray Supercomputer </td></tr>
+    <tr><td> 06:00 </td><td> Hongbo Rong                          </td><td> Sparse Accelerator                  </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 06:10 </td><td> </td><td> Break </td></tr>
+  </table>
+  <table class="row schedule">
+    <tr><td> 06:20 </td><td> </td><td> Closing Remarks </td></tr>
+  </table>
+</div> <!-- container -->
 
 <div class="container">
   <h2 class="text-center border-header"><span>Thanks to our sponsors</span></h2>


### PR DESCRIPTION
There are a lot of talks so it may be a little overwhelming as-is. Thoughts on
a better organizational structure are welcome. I'm thinking maybe each session
should be a javascript drop-down, so at first you get a high-level schedule and
you can click on each heading to get the talks in that session.

Also the sessions that end 10-minutes apart currently make it look like the
last talk is 10-minutes longer than it should be. We can either re-structure to
clarify that or just let it slide.