### PR TITLE
Add abstracts/bios for workshops.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 name: JuliaCoq
 pygments: true
+kramdown:
+  input: GFM

--- a/_data/workshops-sat.csv
+++ b/_data/workshops-sat.csv
@@ -1,0 +1,45 @@
+Name,Biography,Title,Abstract
+"Iain Dunning, Joey Huchette, Miles Lubin, Madeleine Udell","Iain Dunning, Joey Huchette, and Miles Lubin are PhD candidates at the Operations Research Center at MIT. They are early adopters of Julia and developers of JuMP.
+Madeleine Udell, a developer of Convex.jl, is a postdoctoral fellow at the Center for the Mathematics of Information at Caltech. She recently received a PhD in Computational and Mathematical Engineering at Stanford, and will be joining Cornell as an assistant professor in Operations Research and Information Engineering in 2016. All four are members of the JuliaOpt organization, which curates high quality optimization software in Julia.",Solving Optimization Problems with JuliaOpt,"Optimization provides a powerful framework for decision making: from path planning, to resource allocation, to data fitting, and everything in between. There are a variety of powerful open-source and commercial packages for solving structured mathematical optimization problems, but identifying the right framework for a given problem can be tricky. This workshop will introduce JuMP and Convex.jl, two modeling languages under the JuliaOpt organization that allow users to easily express linear, mixed-integer, conic, semidefinite, and nonlinear optimization problems in Julia. So easily, in fact, that the user may not even need to know what these problem types are. These models can then be solved using any package in the JuliaOpt ecosystem that supports the problem type. We will introduce basic syntax, provide an overview of the complementary capabilities of both JuMP and Convex.jl, and walk through a number of hands-on examples using Jupyter notebooks."
+Avik Sengupta,"Avik Sengupta has built risk and trading systems in Java for investment banks for over a decade. Three years ago he discovered Julia, and hasn't looked back since. He is a Julia contributor and the maintainer of a few Julia packages.
+
+",Julia and the World: How to Work with C / C++ / Java / Python / Ruby from Julia.,"From the very beginning, Julia has had first class support for calling native C code. On top of this functionality, language interop with other languages such as Python, Java and Ruby have been developed. 
+
+This workshop will offer a hands on tutorial on using external libraries written in C, C++, Java, Python and Ruby from within Julia
+
+We will focus first and foremost on calling C libraries. We will describe how types are mapped, and see how to pass structs and callback functions. We will then take an indepth look at calling Python and Java code via the PyCall and JavaCall packages. Finally, time permitting, we will briefly touch upon the ability to call Ruby and C++ libraries. "
+Arch D. Robison,"Arch was the lead developer for KAI C++, and the original architect of Intel Threading Building Blocks.  He contributed type-based alias analysis and vectorization support to Julia.  Arch took 2nd place in Al Zimmerman’s “Delacorte Numbers” programming contest using Julia exclusively.  His Erdös number is 3.","Introduction to Writing High Performance Julia
+","This workshop is an introduction to writing high performance code in Julia.  We’ll start with a high level view of the hardware and Julia, and how Julia semantics differ from languages such as C/C++/Fortran.  Next we’ll dive into how Julia compiles your program, all the way from your source text to the machine instructions.  A focus will be on the compiler’s type-inference engine and how to make it work for you instead of against you.   Another focus will be how to cater to the hardware.  We’ll also look at “deals with the devil” annotations (@inbounds, @fastmath, @simd) so that you understand what kind of trade you make with those annotations.  Finally, we’ll look the art of writing vectorizable code, which brings many of the topics into play.
+
+Attendees are encouraged to bring a computer with Julia installed on it so that they can try exercises that involve speeding up slow examples."
+Randy Zwitch,"Randy Zwitch is a Senior Data Scientist/Data Engineer at Comcast, studying how customers consume the its product offerings using Hadoop and related big data technologies.
+
+Randy has contributed mostly unit tests to the main Julia project. He has also created several packages (UAParser, Twitter, OAuth, LogParser) and actively participates in the JuliaWeb organization.",Everyday Analytics and Visualization,"With its initial focus on high-performance and scientific computing, the Julia language can be intimidating for newer users. However, using Julia is not just about being a speed demon; with a clean syntax and rapidly growing package eco-system, Julia can be used for ""everyday"" tasks as summary statistics, accessing web APIs and databases and interactive data visualization.
+
+Randy will demonstrate an end-to-end example of a data analysis workflow, from downloading publicly available data to loading data into Julia, creating summaries and answering business questions using visualization (Gadfly/Plot.ly).
+
+"
+Jacob Quinn,"Currently a technical consultant at Domo in Utah. Just graduated from Carnegie Mellon in Pittsburgh. Developing Julia for about 3 years now, and own/maintain the ODBC, SQLite, SuffixArrays, TimeZones, Dates, and Yelp packages, as well as the Sublime-IJulia package for Sublime Text. Also been involved in several significant projects involve Base Julia functionality.","Managing Data in Julia: Old Tricks, New Tricks","Managing data in any language can be a hassle. Varying file formats, data layouts, character sets, compression techniques, not to mention the actual code for manipulating data.
+
+In this talk, some old standards (ODBC, SQLite) are revisited for their on-going usefulness and stability in managing data, while some new methods are also explored that leverage the power of Julia and novel user interfaces."
+Viral,https://in.linkedin.com/in/viralbshah,Parallel Computing with Julia,"This is a joint workshop with contributions from everyone at the Julia MIT group. I expect we will conduct it jointly, but just submitting something in case nobody else has.
+
+Topics for coverage:
+
+1. remotecall/fetch/spawn
+2. sync / async (not really parallel)
+3. DArrays
+4. pmap
+5. @parallel
+6. Parallel Linear Algebra (Elemental, ScaLapack)
+7. Hadoop
+"
+Shashi,I make UI tools for Julia and JuliaBox users. I brought @manipulate to your IJulia notebooks. :),Making GUIs with Canvas.jl,"While in the talk I want to focus on the implementation details and value proposition of Canvas, I would love for a workshop to allow me to introduce Canvas's end-user API to Julians.
+
+In this workshop I plan to do a hands-on session where we build some cool apps, probably:
+
+- a minesweeper clone
+- a pivot table accompanied by Gadfly plots
+- a simple IPython notebooks clone
+
+or something fun"

--- a/_data/workshops-wed.csv
+++ b/_data/workshops-wed.csv
@@ -1,0 +1,4 @@
+Name,Biography,Title,Abstract
+David P. Sanders,"I am an associate professor of computational physics in the Department of Physics, Faculty of Sciences, National University of Mexico (UNAM). I first heard about Julia in the summer of 2013 at SciPy, but did not really discover it until the beginning of 2014. Since then I have switched to using it full time for both teaching and research. I am an author of the `ValidatedNumerics.jl` and `BilliardModels.jl` packages. At SciPy 2014, I gave a 4-hour Julia tutorial, listed on the Learning section of the Julia web-page, which has over 20,000 views. ",Introduction to Julia for Scientific Computing,"A tutorial introduction to Julia for scientific computing, aimed at people who already know a scientific computing language but are new to Julia.
+
+This will be an improved and streamlined version of my SciPy 2014 tutorial listed at julialang.org/learning, based around Jupyter notebooks."

--- a/_layouts/abstracts.html
+++ b/_layouts/abstracts.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>JuliaCon 2015: Boston, MA.</title>
+        <meta name="description" content="JuliaCon 2015: Boston, MA.">
+        <meta name="viewport" id="viewport" content="width=device-width,maximum-scale=1.5">
+        <meta property="og:site_name" content="JuliaCon">
+        <meta property="og:type" content="website">
+        <meta property="og:title" content="JuliaCon">
+        <meta property="og:description" content="JuliaCon 2015: Boston, MA.">
+        <meta property="og:url" content="http://www.juliacon.com/">
+        <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+
+        <link rel="stylesheet" href="css/juliacon.css">
+        <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+        <script type="text/javascript" src="js/juliacon.js"></script>
+
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+          ga('create', 'UA-28835595-3', 'auto');
+          ga('send', 'pageview');
+
+        </script>
+    </head>
+    <body> 
+        <div class="full-container" style="height: 15rem;">
+            <h1 class="text-center">JuliaCon 2015</h1>
+            <h1 class="text-center">{{page.title}}</h1>
+        </div>
+   {{content}}   
+
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -36,13 +36,14 @@ title: JuliaCon
 
 </div>
 
+<a name="sched"></a>
 <div class="container schedule">
   <div class="row"><h2 class="text-center border-header"><span>Schedule</span></h2></div>
   <div class="row"><h3>Wednesday, June 24</h3></div>
   <div class="row"><span class="track-title">Hackathon and Intro Workshop (Room 32-144)</span></div>
   <table class="row">
     <tr><td> 08:00 </td><td>                                                             </td><td> Hackathon Begins                                       </td></tr>
-    <tr><td> 01:00 </td><td> <a href="https://github.com/dpsanders">David P. Sanders</a> </td><td> Workshop: Invitation to Julia for scientific computing </td></tr>
+    <tr><td> 01:00 </td><td> <a href="https://github.com/dpsanders">David P. Sanders</a> </td><td> <A href="workshops.html#wednesday">Workshop: Invitation to Julia for scientific computing</a> </td></tr>
     <tr><td> 04:00 </td><td>                                                             </td><td> Hackathon Resumes                                      </td></tr>
     <tr><td> 06:30 </td><td>                                                             </td><td> Hackathon Ends                                         </td></tr>
   </table>
@@ -165,7 +166,9 @@ title: JuliaCon
     <tr><td> 06:20 </td><td> </td><td> Closing Remarks </td></tr>
   </table>
   <div class="row"><h3>Saturday, June 27</h3></div>
-  <div class="row"><span class="track-title">Workshops</span></div>
+  <div class="row">
+    <span class="track-title"><a href="workshops.html#saturday">Workshops</span>
+  </div>
   <table class="row schedule">
     <tr><td> 08:30-11:30 </td><td>
         <a href="https://github.com/IainNZ/">Iain Dunning</a>,

--- a/workshops.html
+++ b/workshops.html
@@ -4,7 +4,7 @@ title: Workshops
 datafile: workshops
 ---
 <div class="container">
-    See <a href="index.html">main page</a> for scheduling details.
+    See <a href="index.html#sched">main page</a> for schedule details.
 </div>
 
 <a name="wednesday"><center><h1>Wednesday</h1></center></a>

--- a/workshops.html
+++ b/workshops.html
@@ -1,0 +1,33 @@
+---
+layout: abstracts
+title: Workshops
+datafile: workshops
+---
+<div class="container">
+    See <a href="index.html">main page</a> for scheduling details.
+</div>
+
+<a name="wednesday"><center><h1>Wednesday</h1></center></a>
+{% for member in site.data.workshops-wed %}
+  <div class="container abstract">
+    <p><h2>{{ member.Title }}</h2></p> 
+    <p><em>{{ member.Name }}</em></p>
+    <p>{{ member.Abstract | markdownify }}</p>
+    <p><b>Bio:</b> {{ member.Biography }}</p>
+  </div>
+{% endfor %}
+
+<a name="saturday"><center><h1>Saturday</h1></center></a>
+{% for member in site.data.workshops-sat %}
+  <div class="container abstract">
+    <p><h2>{{ member.Title }}</h2></p> 
+    <p><em>{{ member.Name }}</em></p>
+    <p>{{ member.Abstract | markdownify }}</p>
+    <p><b>Bio:</b> {{ member.Biography }}</p>
+  </div>
+{% endfor %}
+
+<div class="container">
+  <a href="/index.html">Return to main page</a>.
+</div>
+


### PR DESCRIPTION
This PR adds abstracts/bios for workshops.  Once we settle the details, it shouldn't be hard to add the talks as a similar page(s).  I gave the workshops precedence for three reasons:

* Workshops are longer, and so people might want more info before committing time/$ to them.  It would be good to get the abstracts up as soon as practical.
* Some workshops need people to bring a computer.
* Self-interest -- I'm running one of the workshops :-)

Minor issue: Backquotes for literals in the Github-flavored markdown not being interpreted.  The additions to `_config.yml` were supposed to deal with this, but don't.

I'm new to Jekyll, so there may be newbie mistakes or suboptimalities.
