### PR TITLE
Add instructions about using phone number if staying 6/23.  Change end date to June 27th.

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: JuliaCon
   <p class="text-center"><strong>Special hotel pricing available - <a href="#accom">learn more</a></strong></p>
   <p>
     The second <a href="http://www.julialang.org/">Julia</a> conference will
-    take place <strong>June 24th-27th, 2015</strong> (Wednesday-Sunday) at the
+    take place <strong>June 24th-27th, 2015</strong> (Wednesday-Saturday) at the
     Massachusetts Institute of Technology in Cambridge, Massachusetts. Expect
     cutting-edge technical talks, hands-on workshops, a chance to rub
     shoulders with Julia's creators, and a weekend in a city known for its

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: JuliaCon
   <p class="text-center"><strong>Special hotel pricing available - <a href="#accom">learn more</a></strong></p>
   <p>
     The second <a href="http://www.julialang.org/">Julia</a> conference will
-    take place <strong>June 24th-28th, 2015</strong> (Wednesday-Sunday) at the
+    take place <strong>June 24th-27th, 2015</strong> (Wednesday-Sunday) at the
     Massachusetts Institute of Technology in Cambridge, Massachusetts. Expect
     cutting-edge technical talks, hands-on workshops, a chance to rub
     shoulders with Julia's creators, and a weekend in a city known for its
@@ -245,7 +245,7 @@ title: JuliaCon
     Cambridge, MA 02139<br>
   </address>
 
-  <p>The hotel is within walking distance from MIT but a complimentary shuttle service will also be available. Rooms are newly renovated and with free internet access. The rates are:</p>
+  <p>The hotel is within walking distance from MIT. Complimentary shuttle service will also be available. Rooms are newly renovated and with free internet access. The rates are:</p>
 
   <ul>
     <li>Double: $220.00</li>
@@ -255,7 +255,7 @@ title: JuliaCon
 
   <p>The guest room rates are quoted exclusive of applicable state and local taxes (which are currently 14.45%), applicable service fees, and/or hotel-specific fees in effect at the time of the event.</p>
 
-  <p>The special rate is available from <a href="https://resweb.passkey.com/go/juliacon2015">https://resweb.passkey.com/go/juliacon2015</a> or by calling 888-421-1442</p>
+  <p>The block rate is available from <a href="https://resweb.passkey.com/go/juliacon2015">https://resweb.passkey.com/go/juliacon2015</a> or by calling 888-421-1442.  The block rate covers the nights of June 24-27.  For stays including June 23 (Tuesday), call the phone number. The website rejects stays that include June 23.
 
   <p><strong>The block rate is available until June 4, 2015.</strong></p>
 


### PR DESCRIPTION
Four changes:

* Change conference end date from June 28 to June 27.
* Tighten paragraph slightly by replacing "but" with period. 
* Use "block rate" uniformly.  
* Tell people to use phone number, not website, if they are staying night of 6/23.