### PR TITLE
remove custom highlighter configuration setting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
 name: JuliaCoq
-highlighter: pygments
 kramdown:
   input: GFM


### PR DESCRIPTION
Jekyll 3.0 uses rouge by default, and pygments is no longer compatible. This shouldn't actually change the site, since we don't render any code blocks, but it will stop annoying warning emails from the GitHub Pages build service.