### PR TITLE
Add sponsorship info section

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,41 @@ title: JuliaCon
 </div>
 
 <div class="container">
+  <h2 class="text-center border-header"><span>Sponsorship</span></h2>
+  <p>Want to be a JuliaCon 2016 sponsor? Three different sponsorship tiers are available:
+    <div class="container text-center">
+      <table style="border: 0; border-spacing: 10px; width: 100%;">
+        <tr>
+          <th>Donation</th>
+          <th>Tier</th>
+          <th>Complementary Tickets</th>
+          <th>Speaking Slot</th>
+        </tr>
+        <tr>
+          <td>$15000</td>
+          <td>Platinum</td>
+          <td>3 tickets</td>
+          <td>15 minute</td>
+        </tr>
+        <tr>
+          <td>$5000</td>
+          <td>Gold</td>
+          <td>2 tickets</td>
+          <td>10 minute</td>
+        </tr>
+        <tr>
+          <td>$1000</td>
+          <td>Silver</td>
+          <td>1 tickets</td>
+          <td>5 minute</td>
+        </tr>
+      </table>
+    </div>
+  </p>
+  <p>If you're interested in sponsorship, contact Viral Shah at viral@juliacomputing.com.</p>
+</div>
+
+<div class="container">
   <h2 class="text-center border-header"><span>JuliaCon in the past</span></h2>
   <ul>
     <li><a href="http://juliacon.org/2014/">JuliaCon 2014</a></li>


### PR DESCRIPTION
cc @ViralBShah 

This change adds a section that looks like this:

<img width="1677" alt="screen shot 2016-03-11 at 1 39 29 pm" src="https://cloud.githubusercontent.com/assets/3277443/13711883/d01b1a06-e78e-11e5-83ba-a905e1c171f1.png">
