### PR TITLE
Tentative schedule for talks.

### DIFF
--- a/abstracts.html
+++ b/abstracts.html
@@ -16,8 +16,8 @@ title: JuliaCon Talks
 <!-- DO NOT EDIT ENTRIES. EDIT .csv FILES and REGENERATE TABLE WITH gen.jl -->
 <div class="container abstrac">
   <a name="Gallium"><h3>Gallium</h3></a>
-  <em></em>
-  <p></p>
+  <em>Keno Fischer</em>
+  <p>A debugger for Julia</p>
 </div>
 
 <div class="container abstrac">
@@ -185,7 +185,7 @@ The original motivation arose in digital hardware system modeling, but the conce
 <div class="container abstrac">
   <a name="Julia1.0"><h3>Julia 1.0</h3></a>
   <em></em>
-  <p></p>
+  <p>Discussion of Julia 1.0 roadmap</p>
 </div>
 
 <div class="container abstrac">

--- a/abstracts.html
+++ b/abstracts.html
@@ -15,26 +15,16 @@ title: JuliaCon Talks
 
 <!-- DO NOT EDIT ENTRIES. EDIT .csv FILES and REGENERATE TABLE WITH gen.jl -->
 <div class="container abstrac">
-  <a name="FrequonInvaders"><h3>Using Julia as a Quick and Dirty Code Generator</h3></a>
-  <em>Arch D. Robison</em> (Intel Corporation)
-  <p>For a rewrite of Frequon Invaders, I needed a high performance SIMD kernel for a program written in Go, which lacks SIMD support, but does have a bare-bones assembler. Julia to the rescue! Julia turns out to be a nice language for writing a quick and dirty assembly-code generator.  Subtyping and multiple dispatch enabled concisely describing instruction selection.  Julia being a full programming language enabled some automatic register allocation. The exercise shows the power of Julia to quickly hack a limited “one off” program to generate code.</p>
+  <a name="Gallium"><h3>Gallium</h3></a>
+  <em></em>
+  <p></p>
 </div>
 
 <div class="container abstrac">
-  <a name="TeachingJulia"><h3>Teaching first-year college students with Julia</h3></a>
-  <em>John Verzani</em> (CUNY/College of Staten Island)
-  <p>I will describe experiences from trying to use Julia as a replacement for MATLAB to add a computer component to freshman-level calculus at a comprehensive institution. For most students, Julia is their first language, making this class a good test of the ease of adoption of the language. In addition to a list of pros and cons, I'll discuss some of the packages being developed in support of this work.
-</p>
-</div>
-
-<div class="container abstrac">
-  <a name="ParallelAccelerator"><h3>A tour of ParallelAccelerator.jl</h3></a>
-  <em>Lindsey Kuper</em> (Intel Labs)
-  <p>Did you know that your Julia programs could be running much, much faster than they do now?  Recently, the High Performance Scripting team at Intel Labs released ParallelAccelerator.jl, a Julia package that leverages parallel compute resources (such as the multicore computer you probably already have on your desk) and compile-time and run-time optimizations to drastically speed up Julia programs, especially those that do lots of numeric array operations.
-
-In this talk, we'll see some examples of how to use the ParallelAccelerator package, see what kind of speedups are possible, and then take a look at what ParallelAccelerator is doing under the hood.  Finally, we'll step back and discuss the future of parallelism in Julia.
-
-This talk will be of interest to people interested in compilers, macros, parallel computing, array- or vector-style programming, and anyone interested in making their Julia code run faster!</p>
+  <a name="Juno"><h3>Juno, a Julia IDE</h3></a>
+  <em></em>
+  <p>Juno is an effort by the Julia community to provide tooling for the language and build a state of the art programming environment. As well as the various necessities, like evaluation, debugging and plotting, we aim to raise the bar for dynamic tooling in areas like interactivity, visualisation and dynamic analysis.
+Juno is an effort by the Julia community to provide tooling for the language and build a state of the art programming environment. As well as the various necessities, like evaluation, debugging and plotting, we aim to raise the bar for dynamic tooling in areas like interactivity, visualisation and dynamic analysis.</p>
 </div>
 
 <div class="container abstrac">
@@ -45,11 +35,19 @@ On behavioral neuroscience, video analysis helps characterizing several domains 
 </div>
 
 <div class="container abstrac">
-  <a name="HPAT"><h3>HPAT.jl - Easy and Fast Big Data Analytics</h3></a>
-  <em>Ehsan Totoni</em> (Intel Labs)
-  <p>High Performance Analytics Toolkit (HPAT.jl) is a framework for big data analytics on clusters that automatically parallelizes Julia-based analytics programs, and generates efficient MPI/C++ code. HPAT is orders of magnitude faster than systems like Apache Spark. For example, HPAT is 53x faster for Spark’s front-page logistic regression example (200 iterations, 2 billion 10-feature samples) on a 64 nodes (2048 core) system. HPAT is compiler based; it uses Julia’s metaprogramming and ParallelAccelerator under the hoods to apply many optimizations.
+  <a name="DataScience"><h3>Julia for data science: current progress and future plans</h3></a>
+  <em>Simon Byrne</em> (Julia Computing)
+  <p>This talk will give an overview of the current Julia data manipulation and modelling ecosystem, highlight the areas that still need work, and sketch out our future plans.
 
-I will describe how Julia programmers can take advantage of HPAT,jl and what Julia codes are handled.  We’ll then compare the syntax and performance of HPAT.jl with Spark using examples and discuss how it works internally.</p>
+This work is supported by a grant from the Moore Foundation.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="DataTables"><h3>DataTables: Type-safe data containers</h3></a>
+  <em>Andy Ferris</em> (Fugro Roames)
+  <p>Julia's dynamic-yet-statically-compilable type system is extremely powerful, but presents some challenges to creating generic storage containers, like tables of data where each column of the table might have different types. This package attempts to present a fully-typed `Table` container, where elements (rows, columns, cells, etc) can be extracted with their correct type annotation at zero additional run-time overhead. The resulting data can then be manipulated without any unboxing penalty, or the need to introduce unseemly function barriers, unlike existing approaches like the popular DataFrames.jl package. 
+
+The main caveat of this approach is the extra layer of complexity for the compiler and programmer introduced by including this information in the type parameters of objects. This talk will explore how additional Julia 0.5 features such as pure functions will significantly simplify both the interface and the implementation of DataTables.</p>
 </div>
 
 <div class="container abstrac">
@@ -59,11 +57,63 @@ I will describe how Julia programmers can take advantage of HPAT,jl and what Jul
 </div>
 
 <div class="container abstrac">
-  <a name="FiniteElementAnalysis"><h3>Finite Element Analysis in Julia</h3></a>
-  <em>Kristoffer Carlsson</em> (Chalmers University of Technology)
-  <p>Writing a Finite Element Analysis (FEA) code requires many components. We typically need a dense and sparse matrix library, linear solvers for both type of matrices, visualizations of the resulting fields on meshes etc. A typical undergraduate course in FEA will therefore use MATLAB as the programming language in which assignments are written. Since students learn FEA in MATLAB this is also what they are likely to use in an eventual PhD project.
+  <a name="GLVisualize"><h3>Current state of GLVisualize </h3></a>
+  <em>Simon Danisch</em>
+  <p>GLVisualize is a 2D/3D graphics library entirely written in Julia. It uses OpenGL to offer state of the art rendering speeds even for animated data. This Talk will show you what the strength and weaknesses of GLVisualize are, and what you can expect from it in the future.</p>
+</div>
 
-I will make the case that Julia can provide an alternative to MATLAB, both when it comes to teaching FEA and implementing FEA codes in a PhD project. We will look at a handful of packages that together with the base Julia library can make writing FEA codes as simple as it would be in MATLAB.</p>
+<div class="container abstrac">
+  <a name="ForwardDiff"><h3>ForwardDiff.jl: Fast Derivatives Made Easy</h3></a>
+  <em>Jarrett Revels</em> (MIT)
+  <p>Automatic differentiation (AD), a collection of methodologies for computing exact derivatives of programs, is essential for modern scientific computing. In spite of growing awareness of AD, non-expert users face substantial barriers when applying these techniques in practice. These barriers are generally attributable to limitations of the available tools: AD tools developed in low-level languages are difficult to use, and AD tools developed in high-level languages are slow. This talk presents ForwardDiff.jl, a Julia implementation of forward-mode AD that bridges the traditional gap between usability and speed by offering performance competitive with similar C++ implementations. The package leverages Julia's novel performance model to support unique features like black-box function differentiation, simultaneous directional derivative calculation, efficient composability with user-defined types, and experimental parallelism via SIMD/multithreading. The talk will walk the audience through the package's implementation and usage, as well as highlight common AD pitfalls users should avoid.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Vulkan"><h3>Introduction to Vulkan</h3></a>
+  <em>Simon Danisch</em>
+  <p>Vulkan is the successor of OpenGL and OpenCL and offers a lot of interesting new features to do graphics and general compute on the GPU. In this talk I will give a short introduction to Vulkan and why it will matter to Julia.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="ThreeJS"><h3>ThreeJS.jl: Interactive 3D Graphics in the Browser using Julia</h3></a>
+  <em>Rohit Varkey Thankachan</em>
+  <p>ThreeJS.jl is a Julia wrapper around the very popular threejs library for rendering 3D scenes in browsers using JavaScript. This allows the user to create 3D graphics which can be viewed in a browser using just Julia and no HTML or JS. The package can be used along with Escher, IJulia notebooks or from the REPL using Blink.jl. It supports interactivity in Escher, allowing for nice UI’s to interactively update and interact with 3D scenes and also create animations! The talk will demo a few examples to showcase these features and demonstrate the ease of use and presentation quality of web based 3D graphics. ThreeJS.jl was created as part of a JSoC 2015 project mentored by Shashi Gowda and Simon Danisch.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="NetworkViz"><h3>NetworkViz.jl - A Julia interface to visualize graphs using ThreeJS.jl.</h3></a>
+  <em>Abhijith Anilkumar</em> (NITK Surathkal)
+  <p>NetworkViz.jl is a graph visualization package that uses ThreeJS.jl and Escher.jl to render graphs. It can be used to create interactive graph visualization applications. Eg. : 1. https://www.youtube.com/watch?v=qd8LmY2XBHg  2. https://www.youtube.com/watch?v=Ac3cneCRTZo. The package is tightly integrated with LightGraphs.jl and can be used to visualize graph operations using LightGraphs as shown in example 2. The package works decently fast for graphs with nearly 10000. I'm working on optimizing the performance to make it work with larger graphs.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="ForwardRoots"><h3>Enabling reverse communication solvers and embedding Julia</h3></a>
+  <em>Andy Greenwell</em> (Julia Computing, Inc.)
+  <p>This talk provides an overview of a consulting project that had two primary goals: 1. Enable the modification of various forward communication root finding and optimization solvers available in the Julia ecosystem to be used as reverse communication solvers, wherein any objective, gradient, or Hessian functions can be evaluated external to the solver itself.  2. Allow for embedding of the Julia solver within a C/C++ application where the objective, gradient and Hessian functions are defined as part of a large pre-existing codebase.  This talk will walk through the specific Julia functionality necessary to enable a variety of forward communication solvers available in different Julia packages to be called in a reverse communication manner, and show how this functionality can be embedded within a C/C++ application.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="GR"><h3>State of the GR framework</h3></a>
+  <em>Josef Heinen</em> (Forschungszentrum Jülich GmbH)
+  <p>GR is a plotting package for the creation of two- and three-dimensional graphics in Julia, offering basic MATLAB-like plotting functions to visualize static or dynamic data with minimal overhead. In addition, GR can be used as a backend for other plotting interfaces or wrappers, such as PyPlot or Plots. This presentation shows how visualization applications with special performance requirements can be designed on the basis of simple and easy-to-use functions as known from the MATLAB plotting library. The lecture also introduces how to use GR as a backend for Plots, a new plotting interface and wrapper for several Julia graphics packages. By combining the power of those packages the responsiveness of visualization applications can be improved significantly. Using quick practical examples, this talk is going to  present the special features and capabilities provided by the GR framework for high-performance graphics or as a backend for Plots, in particular when being used in interactive notebooks.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="IterativeMethods"><h3>Iterative Methods for  Sparse Linear Systems in Julia: A Quick Overview</h3></a>
+  <em>Lars Ruthotto</em> (Emory University)
+  <p>Efficient iterative methods for sparse linear systems are crucial in many research and industrial applications, for example, for solving partial differential equations (PDEs). There are different Julia packages that provide implementations of many state-of-the-art linear methods. In this lightning talk, I will give an overview about some of the packages and highlight similarities and differences in coding philosophy. I will also give a detailed comparison of their computational efficiency of  using examples from numerical PDEs. The main goal of the talk is to start a discussion about the inevitable trade-offs between computational efficiency, ease of use and readability of the code.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Escher"><h3>Patterns for building web apps with Escher.jl</h3></a>
+  <em>Shashi gowda</em>
+  <p>The talk is about component architecture in Escher.jl. I aim to describe how to build arbitrarily complex web apps from smaller components using a model-view-update pattern.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="VinDsl"><h3>VinDsl.jl: Fast and furious statistical modeling</h3></a>
+  <em>John Pearson</em> (Duke Institute for Brain Sciences)
+  <p>Variational inference is a fast, scalable method for fitting complex statistical models to large and high-dimensional datasets. The repertoire of available algorithms and techniques is expanding rapidly, but most models are still coded by hand. The few automated implementations (e.g., in Stan) face a dual-language problem, and so are less suited to rapid development of new ideas. VinDsl.jl aims to provide a variational inference domain-specific language -- a set of data structures and macros for defining models -- in pure Julia. As a result, existing methods can be mixed and matched and new ones prototyped quickly, creating a thoroughly hackable toolbox for machine learning researchers. In this talk, I'll give an introduction to variational inference and sketch the philosophy and features of VinDsl, ending with applications to some problems in neuroscience.</p>
 </div>
 
 <div class="container abstrac">
@@ -79,73 +129,32 @@ I will make the case that Julia can provide an alternative to MATLAB, both when 
 </div>
 
 <div class="container abstrac">
-  <a name="DataTables"><h3>DataTables: Type-safe data containers</h3></a>
-  <em>Andy Ferris</em> (Fugro Roames)
-  <p>Julia's dynamic-yet-statically-compilable type system is extremely powerful, but presents some challenges to creating generic storage containers, like tables of data where each column of the table might have different types. This package attempts to present a fully-typed `Table` container, where elements (rows, columns, cells, etc) can be extracted with their correct type annotation at zero additional run-time overhead. The resulting data can then be manipulated without any unboxing penalty, or the need to introduce unseemly function barriers, unlike existing approaches like the popular DataFrames.jl package.
-
-The main caveat of this approach is the extra layer of complexity for the compiler and programmer introduced by including this information in the type parameters of objects. This talk will explore how additional Julia 0.5 features such as pure functions will significantly simplify both the interface and the implementation of DataTables.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="ThreeJS"><h3>ThreeJS.jl: Interactive 3D Graphics in the Browser using Julia</h3></a>
-  <em>Rohit Varkey Thankachan</em>
-  <p>ThreeJS.jl is a Julia wrapper around the very popular threejs library for rendering 3D scenes in browsers using JavaScript. This allows the user to create 3D graphics which can be viewed in a browser using just Julia and no HTML or JS. The package can be used along with Escher, IJulia notebooks or from the REPL using Blink.jl. It supports interactivity in Escher, allowing for nice UI’s to interactively update and interact with 3D scenes and also create animations! The talk will demo a few examples to showcase these features and demonstrate the ease of use and presentation quality of web based 3D graphics. ThreeJS.jl was created as part of a JSoC 2015 project mentored by Shashi Gowda and Simon Danisch.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="MatrixNetworks"><h3>Network Algorithms Research in Julia</h3></a>
-  <em>Huda Nassar</em> (Purdue University)
-  <p>Datasets in many research disciplines involve large networks; examples include biological datasets, transportation networks, and social media networks. In this talk, we will describe how we are using Julia in our research into new network algorithms and why we created the MatrixNetworks.jl package to bridge between the linear algebra routines in Julia and the network algorithms. We will discuss algorithms that we have recently created for graph diffusions and network alignment methods where having methods that interface between these representations is essential. </p>
-</div>
-
-<div class="container abstrac">
-  <a name="RaspberryPi"><h3>Minecraft and LEDs : Julia on the Raspberry Pi</h3></a>
-  <em>Avik Sengupta</em> (Algocircle Ltd)
-  <p>The Raspberry Pi is a $35 computer designed to help teach computing to kids. It has also turned out to be very popular among hobbyists and digital makers. Powered by a  ARM processor, it now runs Julia well enough to enable some fun educational projects. This talk will demonstrate the most common activities that kids can do with a Raspberry Pi -- control Minecraft via its API, and perform physical computing via its GPIO pins to control external components. It will showcase the Julia packages used for this purpose, and discuss ways in which these can be used to teach maths, science and programming. </p>
-</div>
-
-<div class="container abstrac">
-  <a name="ForwardDiff"><h3>ForwardDiff.jl: Fast Derivatives Made Easy</h3></a>
-  <em>Jarrett Revels</em> (MIT)
-  <p>Automatic differentiation (AD), a collection of methodologies for computing exact derivatives of programs, is essential for modern scientific computing. In spite of growing awareness of AD, non-expert users face substantial barriers when applying these techniques in practice. These barriers are generally attributable to limitations of the available tools: AD tools developed in low-level languages are difficult to use, and AD tools developed in high-level languages are slow. This talk presents ForwardDiff.jl, a Julia implementation of forward-mode AD that bridges the traditional gap between usability and speed by offering performance competitive with similar C++ implementations. The package leverages Julia's novel performance model to support unique features like black-box function differentiation, simultaneous directional derivative calculation, efficient composability with user-defined types, and experimental parallelism via SIMD/multithreading. The talk will walk the audience through the package's implementation and usage, as well as highlight common AD pitfalls users should avoid.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="BaseTestAuto"><h3>Finding Julia Bugs Automatically</h3></a>
-  <em>Robert Feldt</em> (Blekinge Inst of Technology)
-  <p>The ability to thoroughly, but easily, test Julia code and packages is vital if they are to maintain their high quality. The Base.Test framework provides a great set of constructs to help automatically execute test cases and avoid bugs. Recently we have extended this framework with award-winning techniques from our software testing research. Together, these packages enable not only the automated execution but also the automated creation of test cases. This can help you explore the actual behavior of your Julia code to find bugs earlier and increase coverage. In this talk we give an overview of the techniques our extensions provide, and show, with examples, how they have helped us find bugs in Julia code.
-
-Our extensions combine the novel capabilities of a number of different testing frameworks, programming languages and research studies. The BaseTestAuto package provides the basis by extending the Base.Test implementation in Julia 0.5-dev to support repeated execution of test sets and to allow predicates that ensure not only a single but that a whole set of values have a certain property. Another package allows generators for values of any type and structure to be described; this allows for both random and targetted creation of test data. On top of this we can then build a library of generators and combinators to create data that exercises a large part of the Julia type hierarchy. Together these packages extend the type of testing that can now be done in Julia, and in our presentation we will demonstrate random testing, property-based testing, parameterized unit testing, adaptive test execution, and search-based testing for increased coverage and test diversity. Our talk is hands-on and shows the use of these techniques on real Julia code but also outlines future additions that we are working on. Our mission is to make testing in Julia as fun and powerful as possible and we hope to get support from the community in achieving this.</p>
-</div>
-
-<div class="container abstrac">
   <a name="ExtendedFloats"><h3>The design and use of extended precision floats</h3></a>
   <em>Jeffrey Sarnoff</em> (Diadem Special Projects LLC)
   <p>I would like to give a talk on Float-like types that extend mathematical accuracy and help to assure mathematical veracity.  The talk introduces errorfree transformations and compensated arithmetic for ~128 bit precision and good options for higher precision.  Aspects of design and use are explained using a few elaborated types I have written.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="BoundsChecks"><h3>Bounds check elimination in Julia v0.5</h3></a>
-  <em>Blake Johnson</em> (Raytheon BBN Technologies)
-  <p>Consistent with Julia's philosophy of having *both* performance and safety, it is important to have bounds checks on array accesses by default, as well as a means to eliminate such checks when the compiler or user can prove that they are unnecessary. Julia v0.5 introduces a new mechanism for user-extensible bounds checking and elimination via simple call-site decoration. In this talk, I will discuss the design approach and show off some of the internals of the implementation. Finally, I will show how to take advantage of this new feature for custom array types.</p>
+  <a name="CxxWrap"><h3>CppWrapper: Write Julia modules in C++</h3></a>
+  <em>Bart Janssens</em> (Royal Military Academy of Belgium)
+  <p>The CppWrapper package helps to expose C++ libraries as a Julia module. The  main difference with Cxx.jl is that the wrappers are in C++ and loaded into Julia as a shared library. This can be useful for large libraries, where the wrapping library can be precompiled. The wrapper can be bundled with the library, automatically ensuring it compiles when updating the C++ library.
+
+In this talk, first the use of the package will be illustrated with a simple example. Next, some aspects of the implementation will be highlighted. The package is based on a combination of ccall and embedded use of the Julia C interface, so this will be explained in detail. On the Julia side, some metaprogramming techniques -used to generate methods- will be shown.
+
+In summary, this talk is targeted at people who are interested in wrapping C++ libraries, want to use the Julia C interface (embedding) or see an example of metaprogramming to define new methods.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="RaceCars"><h3>Autonomous driving for RC cars with ROS and Julia</h3></a>
-  <em>Jon Gonzales</em> (University of California Berkeley)
-  <p>Our research focuses on control algorithms for automotive applications. We use model predictive control (MPC) as a mathematical tool to design these algorithms, and then use Julia and Python to implement these algorithms. For experimentation, we have launched an open-source platform called Berkeley Autonomous Race Car (BARC), which is a 1/10th scale RC car equipped with hardware for autonomous driving. [ http://www.barc-project.com/ ].  </p>
-</div>
+  <a name="APL"><h3>APL at Julia's speed</h3></a>
+  <em>Shashi Gowda</em>
+  <p>A look at why Julia is the best language to implement APL and how the JIT fares in the face of adversities. (https://github.com/shashi/APL.jl)
 
-<div class="container abstrac">
-  <a name="GR"><h3>State of the GR framework</h3></a>
-  <em>Josef Heinen</em> (Forschungszentrum Jülich GmbH)
-  <p>GR is a plotting package for the creation of two- and three-dimensional graphics in Julia, offering basic MATLAB-like plotting functions to visualize static or dynamic data with minimal overhead. In addition, GR can be used as a backend for other plotting interfaces or wrappers, such as PyPlot or Plots. This presentation shows how visualization applications with special performance requirements can be designed on the basis of simple and easy-to-use functions as known from the MATLAB plotting library. The lecture also introduces how to use GR as a backend for Plots, a new plotting interface and wrapper for several Julia graphics packages. By combining the power of those packages the responsiveness of visualization applications can be improved significantly. Using quick practical examples, this talk is going to  present the special features and capabilities provided by the GR framework for high-performance graphics or as a backend for Plots, in particular when being used in interactive notebooks.</p>
-</div>
+- parsing examples https://github.com/shashi/APL.jl/blob/master/src/parser.jl
+- eval-apply https://github.com/shashi/APL.jl/blob/master/src/eval.jl
+- what's inside a function?
+- some @code_llvm samples
 
-<div class="container abstrac">
-  <a name="Vulkan"><h3>Introduction to Vulkan</h3></a>
-  <em>Simon Danisch</em>
-  <p>Vulkan is the successor of OpenGL and OpenCL and offers a lot of interesting new features to do graphics and general compute on the GPU. In this talk I will give a short introduction to Vulkan and why it will matter to Julia.</p>
+see this gist for a demo https://gist.github.com/shashi/9ad9de91d1aa12f006c4</p>
 </div>
 
 <div class="container abstrac">
@@ -155,15 +164,61 @@ Our extensions combine the novel capabilities of a number of different testing f
 </div>
 
 <div class="container abstrac">
-  <a name="ArrayFire"><h3>Accelerating Julia Kernels with ArrayFire</h3></a>
-  <em>Ranjan Anantharaman</em>
-  <p>Accelerated computing has become increasingly popular in the scientific community over the past few years. However, a common challenge is the dearth of easy high-level APIs. This talk is about using the package ArrayFire.jl to write accelerated kernels in Julia with easy Julian APIs. It is designed to mimic Base Julia in its versatility and ease of use, and allows you to switch between three backends: CPU, OpenCL and CUDA, without changing any code. This talk would demonstrate those capabilities and interesting applications using ArrayFire.</p>
+  <a name="FrequonInvaders"><h3>Using Julia as a Quick and Dirty Code Generator</h3></a>
+  <em>Arch D. Robison</em> (Intel Corporation)
+  <p>For a rewrite of Frequon Invaders, I needed a high performance SIMD kernel for a program written in Go, which lacks SIMD support, but does have a bare-bones assembler. Julia to the rescue! Julia turns out to be a nice language for writing a quick and dirty assembly-code generator.  Subtyping and multiple dispatch enabled concisely describing instruction selection.  Julia being a full programming language enabled some automatic register allocation. The exercise shows the power of Julia to quickly hack a limited “one off” program to generate code.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="ComputeFramework"><h3>ComputeFramework.jl - A framework and scheduler for parallel computing</h3></a>
-  <em>Shashi Gowda</em>
-  <p>ComputeFramework is a package that has a scheduler similar to that of Dask (dask.pydata.org) which minimizes memory footprint in parallel programs allowing processing of huge amounts of data even on a single machine with limited RAM.</p>
+  <a name="BoundedIntegers"><h3>Bounded Integers with Type-Level Constants </h3></a>
+  <em>David Hossack</em> (Analog Devices)
+  <p>I will describe the implementation of a bounded integer type in Julia, where the bounds are encoded as type level constants.  All the usual arithmetic operations on integers are implemented with the result bounds being determined once at (JIT) compile time.  For example adding bounded integers with types BInt{-10,8} and BInt{-100, 20} will yield a bounded integer with type BInt {-110, 28}.
+
+The bounds can be any constant integer, and large bounds are automatically converted to a tuple format that allows extremely large (effectively unbounded) integers to be represented at the type level despite Julia’s current limitation that the type parameter be a “bits type”.  The appropriate value type is determined from the bounds - this can be Int32, Int64, Int128 or BigInt as required.
+
+The implementation exploits @generated functions to make the type level decisions.
+
+The original motivation arose in digital hardware system modeling, but the concept is very general.  The bounded integer “BInt” numeric type behaves like BigInt in that arithmetic on BInt values will never overflow, but without the runtime and storage overhead of BigInt when it can be determined that a fixed width type is sufficient.
+</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Julia1.0"><h3>Julia 1.0</h3></a>
+  <em></em>
+  <p></p>
+</div>
+
+<div class="container abstrac">
+  <a name="RaceCars"><h3>Autonomous driving for RC cars with ROS and Julia</h3></a>
+  <em>Jon Gonzales</em> (University of California Berkeley)
+  <p>Our research focuses on control algorithms for automotive applications. We use model predictive control (MPC) as a mathematical tool to design these algorithms, and then use Julia and Python to implement these algorithms. For experimentation, we have launched an open-source platform called Berkeley Autonomous Race Car (BARC), which is a 1/10th scale RC car equipped with hardware for autonomous driving. [ http://www.barc-project.com/ ].  </p>
+</div>
+
+<div class="container abstrac">
+  <a name="RaspberryPi"><h3>Minecraft and LEDs : Julia on the Raspberry Pi</h3></a>
+  <em>Avik Sengupta</em> (Algocircle Ltd)
+  <p>The Raspberry Pi is a $35 computer designed to help teach computing to kids. It has also turned out to be very popular among hobbyists and digital makers. Powered by a  ARM processor, it now runs Julia well enough to enable some fun educational projects. This talk will demonstrate the most common activities that kids can do with a Raspberry Pi -- control Minecraft via its API, and perform physical computing via its GPIO pins to control external components. It will showcase the Julia packages used for this purpose, and discuss ways in which these can be used to teach maths, science and programming. </p>
+</div>
+
+<div class="container abstrac">
+  <a name="JuliaBox"><h3>Overview of the new JuliaBox</h3></a>
+  <em>Nishanth</em>
+  <p>JuliaBox is currently hosted on AWS but will be hosted on Google cloud in the future. This talk gives the necessary information needed for users to migrate their data. The new features available for free/paid users and the road map for future development will also be presented.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="TeachingJulia"><h3>Teaching first-year college students with Julia</h3></a>
+  <em>John Verzani</em> (CUNY/College of Staten Island)
+  <p>I will describe experiences from trying to use Julia as a replacement for MATLAB to add a computer component to freshman-level calculus at a comprehensive institution. For most students, Julia is their first language, making this class a good test of the ease of adoption of the language. In addition to a list of pros and cons, I'll discuss some of the packages being developed in support of this work.
+</p>
+</div>
+
+<div class="container abstrac">
+  <a name="HPAT"><h3>HPAT.jl - Easy and Fast Big Data Analytics</h3></a>
+  <em>Ehsan Totoni</em> (Intel Labs)
+  <p>High Performance Analytics Toolkit (HPAT.jl) is a framework for big data analytics on clusters that automatically parallelizes Julia-based analytics programs, and generates efficient MPI/C++ code. HPAT is orders of magnitude faster than systems like Apache Spark. For example, HPAT is 53x faster for Spark’s front-page logistic regression example (200 iterations, 2 billion 10-feature samples) on a 64 nodes (2048 core) system. HPAT is compiler based; it uses Julia’s metaprogramming and ParallelAccelerator under the hoods to apply many optimizations.
+
+I will describe how Julia programmers can take advantage of HPAT,jl and what Julia codes are handled.  We’ll then compare the syntax and performance of HPAT.jl with Spark using examples and discuss how it works internally.</p>
 </div>
 
 <div class="container abstrac">
@@ -190,11 +245,57 @@ START project no. Y660 "PDE Models for Nanotechnology".</p>
 </div>
 
 <div class="container abstrac">
-  <a name="DataScience"><h3>Julia for data science: current progress and future plans</h3></a>
-  <em>Simon Byrne</em> (Julia Computing)
-  <p>This talk will give an overview of the current Julia data manipulation and modelling ecosystem, highlight the areas that still need work, and sketch out our future plans.
+  <a name="OnlineStats"><h3>OnlineStats.jl: Statistics for Streaming and Big Data</h3></a>
+  <em>Josh Day</em> (NC State University)
+  <p>Statistical algorithms are typically based around data fixed in size.  Adapting methods to data which is streaming or too large to fit in memory is often nontrivial.  OnlineStats.jl provides a state of the art toolkit for performing statistical analysis in these situations.  All algorithms use O(1) memory and stochastic approximations are used where analytical solutions are not possible.  The methods provided by OnlineStats.jl include summary statistics, density estimation, statistical learning, and more.</p>
+</div>
 
-This work is supported by a grant from the Moore Foundation.</p>
+<div class="container abstrac">
+  <a name="FiniteElementAnalysis"><h3>Finite Element Analysis in Julia</h3></a>
+  <em>Kristoffer Carlsson</em> (Chalmers University of Technology)
+  <p>Writing a Finite Element Analysis (FEA) code requires many components. We typically need a dense and sparse matrix library, linear solvers for both type of matrices, visualizations of the resulting fields on meshes etc. A typical undergraduate course in FEA will therefore use MATLAB as the programming language in which assignments are written. Since students learn FEA in MATLAB this is also what they are likely to use in an eventual PhD project.
+
+I will make the case that Julia can provide an alternative to MATLAB, both when it comes to teaching FEA and implementing FEA codes in a PhD project. We will look at a handful of packages that together with the base Julia library can make writing FEA codes as simple as it would be in MATLAB.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="DataStreams"><h3>DataStreams: Workflows for Data Processing Tasks</h3></a>
+  <em>Jacob Quinn</em> (Domo)
+  <p>Julia's core language performance has attracted developers for years. In terms of standardized data processing tasks, however, Julia has lagged peer tools in terms of functionality and convenience. The DataStreams package and framework aims to bring foundational tools and workflows to Julia that encourage interface consistency and automatic leveraging of Julia's built-in performance levers. The CSV, SQLite, and ODBC packages currently implement the DataStreams framework to provide foundational data processing tools for Julia data mungers.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Astrodynamics"><h3>Astrodynamics.jl: Modern Spaceflight Dynamics in Julia</h3></a>
+  <em>Helge Eichhorn</em> (Technische Universität Darmstadt, Germany)
+  <p>The motion of a spacecraft is governed by non-linear equations which makes numerical software tools indispensable for the development and operations of a space mission. Since the beginning of computational astrodynamics Fortran has been the language of choice due to the numerical performance requirements. Because Fortran is not exactly flexible and easy to work with many astrodynamicists use Matlab for prototyping algorithms. This has led to the familiar pattern of software tools being implemented twice, first in Matlab then in Fortran, or interfacing Matlab and Fortran through MEX-files and hundreds of lines of glue code.
+
+In this talk I will present the Astrodynamics.jl library and explore how Julia’s unique feature set enables fast and easy modeling of complex space missions while not requiring expensive licenses or juggling multiple programming languages. With Julia it is possible to seamlessly move from simple approximations to parallel high-fidelity simulations which makes it an excellent choice for designing future space missions.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="LeastSquares"><h3>Least Squares with high dimensional variables</h3></a>
+  <em>Matthieu Gome</em>
+  <p>This talk would discuss various statistical models that require to solve sparse least square problems. I'll explain why these models are useful in social sciences, why they are hard to solve, and how to solve them in Julia.
+
+I'll go through 2 examples:
+The first example is the class of linear regression models with high dimensional categorical variables. When there is a lot of groups, we simply cannot form the design matrix of all group dummies. I'll go though the best solution methods to solve these models, in term of speed, numerical stability, memory, &amp; standard errors. 
+The solution method is available in the package: https://github.com/matthieugomez/FixedEffectModels.jl
+The package is an order of magnitude faster than similar packages in R or Stata. (The package is also the first Julia package that allows to estimate models with instrumental variables)
+
+The second example is a PCA on a sparse panel. Think of the Netflix dataset: a user typically rates only a few movies so we have only a few non missing observations in the space user x movie. Estimating a PCA in this case requires to solve a sparse non linear least squares
+Relevant package:
+https://github.com/matthieugomez/SparseFactorModels.jl
+I don't know of a similar package in another language.
+
+Both of these packages use a general backend:
+https://github.com/matthieugomez/LeastSquaresOptim.jl
+This backend solves general sparse least square problems in Julia.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="GWAS"><h3>A novel algorithm for model selection in genome-wide association studies</h3></a>
+  <em>Kevin L. Keys</em> (University of California, Los Angeles)
+  <p>Genome-wide association studies (GWASes) examines phenotypic variation in a sample of patients genotyped at several places on the genome. Since GWASes were introduced in 2005, researchers have performed GWASes for hundreds of traits on thousands of individuals. GWASes produce massive quantities of data that present computational and model selection challenges to their analysis. Prevalent among GWAS analyses is a noticeable failure to explain substantial portions of the observed phenotypic variance. We exploit iterative hard thresholding (IHT) to effectively select genetic markers informative for continuous traits. Preliminary tests suggest that our implementation effectively controls type I errors better than both LASSO- and MCP-penalized linear regression. Our scalable implementation enables GWAS analysis on both desktop machines and computing clusters.</p>
 </div>
 
 <div class="container abstrac">
@@ -215,6 +316,56 @@ We will show how these ideas can be used to obtain precise and rigorous results 
 </div>
 
 <div class="container abstrac">
+  <a name="OpenMendel"><h3>OpenMendel Project</h3></a>
+  <em>Hua Zhou</em> (UCLA)
+  <p>Mendel (https://www.genetics.ucla.edu/software/mendel) is a comprehensive statistical genetic analysis program, developed by biomathematician Kenneth Lange (http://people.healthsciences.ucla.edu/institution/personnel?personnel_id=45702) and his colleagues at UCLA. The current version of Mendel consists of more than 75,000 lines of dense Fortran 2008 code. Documentation exceeds 300 pages. Software development in statistical genetics is currently chaotic, and some consolidation is inevitable. The challenge is to accomplish this in a manner that enhances rather than stifles creativity. OpenMendel is an open source project that rewrites Mendel using the elegant and efficient language Julia. Its code base will serve as a platform for the truly large genetics studies now being launched and enables researchers to quickly tailor it to their specific needs. This talk outlines the vision and status of the OpenMendel project.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="MusicIR"><h3>Music Information Retrieval in Julia</h3></a>
+  <em>Jong Wook Kim</em> (New York University)
+  <p>Music Information Retrieval (MIR) is an exciting field of research with many successful real-world applications, such as automatic audio source separation, instrument recognition, chord recognition, automatic transcription and music recommender systems. In this lightning talk, I will briefly introduce MIR as a research topic, and show how Julia can be used to perform various music analysis and processing required in MIR research. The presentation will also include a demo of audio visualization and instrument classification, based on a music analysis library written in Julia that is planned to be open sourced by JuliaCon 2016.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="WordEmbeddings"><h3>Fun with Word Embeddings in Julia</h3></a>
+  <em>Sisir Koppaka</em> (Data Scientist, x.ai)
+  <p>Word embeddings allow us to represent words, phrases, and even sentences as vectors in a hyperspace. This helps us in better capturing syntactic and semantic similarities between natural language entities based on distributional properties of various corpora. I'll briefly introduce the idea, and step visually into the process with a pure-Julia implementation. The backdrop of the discussion will be a year of practical learnings on shortening the feedback loop in ML at a fast-pace ML/NLP-driven startup.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="RobotNavigation"><h3>Towards a nonparametric belief solution for factor graphs</h3></a>
+  <em>Dehann Fourie</em> (MIT/WHOI Joint Program)
+  <p>We relax parametric inference to a non-parametric representation over the Bayes tree, towards more general factor graph solutions. We use Gaussian Mixture models to represent a wider class of constraint beliefs, including multi-hypothesis inference. The Bayes tree factorization maximally exploits the structure of the true joint posterior, thereby minimizing computation. We use approximate non-parametric belief propagation over the cliques of the Bayes tree to reduce the computational complexity. Robotic navigation and mapping is our focused application. Our implementation has been written entirely in the Julia language, exploiting high performance and parallel computing.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="DSGE"><h3>DSGE.jl – Using Julia for Economic Modeling at the Federal Reserve Bank of New York </h3></a>
+  <em>Erica Moszkowski</em> (Federal Reserve Bank of New York)
+  <p>This talk will describe how researchers in the Federal Reserve Bank of New York’s DSGE Team use Julia for macroeconomic modeling.  In collaboration with the QuantEcon team, we ported our code for solving dynamic stochastic general equilibrium (DSGE) models to Julia, releasing the source code in the DSGE.jl package in December. DSGE models describe how economic agents behave, given some assumptions about the underlying environment, including fiscal and monetary policy regimes, price rigidities, credit frictions, and various economic shocks.  The FRBNY model is a relatively large model of the U.S. economy, has been used for research on the dynamics of inflation during the great recession, the effects of forward guidance, and much more. 
+
+The DSGE.jl package facilitates the solution and Bayesian estimation of DSGE models. We provide the FRBNY model as one example, but give details on how users can define completely different models.  In this talk, I will give a brief overview of the model and our experience porting the code from MATLAB to Julia (including perspective on using Julia in a "production" setting at a public policy institution). Finally, I will touch on the Julia features our team has found most useful for economic modeling</p>
+</div>
+
+<div class="container abstrac">
+  <a name="BioJulia"><h3>BioJulia: Towards Bioinformatics in the Real World</h3></a>
+  <em>Kenta Sato (@bicycle1885)</em> (GSOC student)
+  <p>BioJulia is a collaborative and open source project to make an infrastructure for bioinformatics. Although we have developed many features, we still lack common tools that are indispensable in the real world. In the project this year, we will implement new tools including online sequence search, data structure for reference genomes, BAM and CRAM parsers, VCF and GFF3 parsers, and integration with genome browsers and biological databases. These things will enable you to use the Julia language in your bioinformatics work and will make it much easier to develop new algorithms and softwares. In this talk, I will present what happened in the recent BioJulia project and what will happen in it for the next months.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="TwoCultures"><h3>The Two Cultures of Programming</h3></a>
+  <em>Joshua Ballanco</em>
+  <p>In 1959 C.P. Snow's famous lecture, "The Two Cultures", decried the failure of educated people in the sciences and humanities to work together. Today we have a similar divide opening between those who write software for science and those who write it for "everything else". In this talk, we'll review the current state of affairs and look at what Julia might do to remedy the situation. The hope is that Julia can be a great programming language not just for science, but for programmers everywhere.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="GraphLayout"><h3>Backend Agnostic GraphLayout.jl</h3></a>
+  <em>Abhijith Anilkumar</em> (GSOC student)
+  <p>Graph visualization is one of the fundamental parts of many modern applications like network analysis. Currently, many packages are available in Julia that can be used for visualizing graphs. But all these packages are tailored to work with a specific backend and it is tedious to write separate code for each package as the requirement changes. To tackle this issue, in this project, we will extend GraphLayout.jl (an existing graph visualization package that uses Compose.jl) to be backend-agnostic. The result will facilitate many applications to use the package and switch between backends used to visualize graphs with minimal changes in the code used. GraphLayout.jl will be modified to generate an intermediate Geometric Type, similar to what is discussed in this issue in GeometryTypes.jl using StructsOfArrays. Therefore, any backend that supports this type can be used to render graphs. Completion of this project will eliminate the redundant code present in visualization packages created for different backends.</p>
+</div>
+
+<div class="container abstrac">
   <a name="MachineCode"><h3>Machine Code</h3></a>
   <em>Jameson Nash</em> (Julia Computing)
   <p>An algorithmic sampling of getting Julia to run fast
@@ -223,25 +374,80 @@ Possible subtopics include: type-inference, high-level optimizations, call devir
 </div>
 
 <div class="container abstrac">
-  <a name="NetworkViz"><h3>NetworkViz.jl - A Julia interface to visualize graphs using ThreeJS.jl.</h3></a>
-  <em>Abhijith Anilkumar</em> (NITK Surathkal)
-  <p>NetworkViz.jl is a graph visualization package that uses ThreeJS.jl and Escher.jl to render graphs. It can be used to create interactive graph visualization applications. Eg. : 1. https://www.youtube.com/watch?v=qd8LmY2XBHg  2. https://www.youtube.com/watch?v=Ac3cneCRTZo. The package is tightly integrated with LightGraphs.jl and can be used to visualize graph operations using LightGraphs as shown in example 2. The package works decently fast for graphs with nearly 10000. I'm working on optimizing the performance to make it work with larger graphs.</p>
+  <a name="ParallelGraph"><h3>Parallelized graph processing in Julia</h3></a>
+  <em>Pranav Thulasiram Bhat</em> (GSOC student)
+  <p>I hope to develop a package, ParallelGraphs, that enables the analysis and manipulation of massive graphs in a distributed environment. The package will support vertex and edge properties through N-Dimensional sparse arrays. The package will be integrated with LighGraphs.jl and ComputeFramework for the serial and parallel execution of graph algorithms. I hope to also incorporate a query model that will let data scientists issue SQL like queries on the graph structure.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="QuantumDynamics"><h3>QuDynamics - Framework for solving Dynamical Quantum Equations.</h3></a>
-  <em>Amit Jamadagni</em>
-  <p>QuDynamics is a Julia package which provides a framework for solving dynamical equations arising in Quantum Mechanics. The current version includes support for solving Schrodinger equations, Liouville von Neumann equations and Lindblad master equations with methods which have been integrated from various other Julia packages like ODE.jl, ExpmV.jl, Expokit.jl. The aim of the talk is to introduce QuDynamics with some examples, and focus on ongoing work to equip QuDynamics with additional features such as Monte-Carlo parallelization, addition of new solvers among many others.
-
-The repo is being maintained at
-
-https://github.com/JuliaQuantum/QuDynamics.jl.</p>
+  <a name="Vectorize"><h3>Cross-platform vectorization using Accelerate, Yeppp! and VML</h3></a>
+  <em>Remy Prechelt</em> (GSOC student)
+  <p>Apple's Accelerate, Yeppp!, and Intel's VML provide high-performance implementations of many common vector functions and operations. Traditionally, use of these libraries required specific intervention by the programmer, and familiarity with Julia's C interface. By taking advantage of Julia's LLVM backend, and detailed benchmarking on package install, I aim to dynamically map Julia functions to the fastest vectorized equivalents available on a specific Julia installation. By building a common interface to these libraries, the same code that was written on OS X linking against Accelerate, can automatically be run without change on Windows linking against VML, and can automatically be run without change on Linux linking against Yeppp!. </p>
 </div>
 
 <div class="container abstrac">
-  <a name="OpenMendel"><h3>OpenMendel Project</h3></a>
-  <em>Hua Zhou</em> (UCLA)
-  <p>Mendel (https://www.genetics.ucla.edu/software/mendel) is a comprehensive statistical genetic analysis program, developed by biomathematician Kenneth Lange (http://people.healthsciences.ucla.edu/institution/personnel?personnel_id=45702) and his colleagues at UCLA. The current version of Mendel consists of more than 75,000 lines of dense Fortran 2008 code. Documentation exceeds 300 pages. Software development in statistical genetics is currently chaotic, and some consolidation is inevitable. The challenge is to accomplish this in a manner that enhances rather than stifles creativity. OpenMendel is an open source project that rewrites Mendel using the elegant and efficient language Julia. Its code base will serve as a platform for the truly large genetics studies now being launched and enables researchers to quickly tailor it to their specific needs. This talk outlines the vision and status of the OpenMendel project.</p>
+  <a name="HTTP2"><h3>Implementing HTTP/2 for Julia</h3></a>
+  <em>Wei Tang</em> (GSOC student)
+  <p>This project is about implementing HTTP/2 for HTTPServer.jl and Requests.jl, as well as implementing a heuristic for Mux.jl for HTTP/2’s “server push”. In the end, It is expected that Mux.jl, HTTPServer.jl and Request.jl users can seamlessly transit to HTTP/2 with little changes on their sides.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="InterTut"><h3>Julia Interactive Tutorial System</h3></a>
+  <em>Matthew Lake (via video)</em> (GSOC student)
+  <p>A short talk about my Google Summer of Code project to create a Julia program for completing interactive tutorials, being available in the REPL and in Juno, with a webpage interface as a stretch goal. Paired with this will be a tool for creating these lessons, and a central repository from which students can download tutorials and to which tutorial creators can upload.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Documenter"><h3>Documenting Julia packages</h3></a>
+  <em>Morten Piibeleht</em> (GSOC student)
+  <p>Documenting packages with JuliaDocs/Documenter.jl -- what it can do for you and an overview of the latest developments.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Convex"><h3>Support for complex-domain optimization problems in Convex.jl</h3></a>
+  <em>Ayush Pandey</em> (GSOC student)
+  <p>Many problems in applied sciences are posed as optimization problems over the complex field such as phase retrieval from sparse signals, designing an FIR filter given desired frequency response, optimization problems in AC power systems, frequency domain analysis in signal processing and control theory.
+The present approach is to manually convert the complex-domain problems to real-domain problems and pass to solvers. This process can be time-consuming and non-intuitive sometimes. The correct approach to such problem would be to make existing packages deal with complex-domain optimization hence making it easier for the optimization community to deal with complex-domain optimization problem. I am extending the above functionality in Convex.jl (a julia package for disciplined convex programming).</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Presolve"><h3>Presolve Routines for Optimization Problems</h3></a>
+  <em>Ramchandran M</em> (GSOC student)
+  <p>Pre-solving is the process of detecting redundancy in the optimization problem and removing them so that optimization problems that are fed to solvers are properly formulated. The reduced optimization problem is now solved by the solver. This has the two-fold benefit of speeding up the optimization process and
+also higher accuracy in solutions. Since smaller problems are fed to the solver (eg. SCS) , the bottleneck call to the solver has now become faster</p>
+</div>
+
+<div class="container abstrac">
+  <a name="ODE"><h3>A Review of a Recently Implemented Implicit and Adaptive ODE Solver based on Adam-Bashforth-Multon Methods</h3></a>
+  <em>Joseph Obiajulu</em> (GSOC student)
+  <p>ODE.jl is an ever increasing store house of numerical solvers of ordinary differential equations available to Julia users. While many solvers are in ODE.jl, there are still well-known and well-performing solvers which are awaiting a native Julia implementation (especially implicit solvers for stiff ODEs). Here we review an implicit and adaptive step-size solver based on the Adam-Bashforth-Multon method which we have implemented in the Julia Language. Although development is still ongoing and final revisions are necessary before merging into ODE.jl, we present preliminary performance results of the solver using the ever expanding IVPTestSuite.jl package.
+
+EDIT
+</p>
+</div>
+
+<div class="container abstrac">
+  <a name="Images"><h3>Exposure Correction and Feature Extraction with Images.jl</h3></a>
+  <em>Anchit Navelkar</em> (GSOC student)
+  <p>The ideal keypoint detector finds salient image regions such that they are repeatably detected despite change of viewpoint and more generally it is robust to all possible image transformations. Similarly, the ideal keypoint descriptor captures the most important and distinctive information content enclosed in the detected salient regions, such that the same structure can be recognized if encountered. The primary aim of my GSoC project is to develop ImageFeatures.jl, a package for keypoint extraction. I am also working on the exposure correction functions of Images.jl.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="ProgQuery"><h3>When is my calculation done? Programmatic query for the status of long calculations</h3></a>
+  <em>Juan Antonio López Mendoza</em> (GSOC student)
+  <p>Linear equations and linear algebra in general have a wide range of applications, some of them even critical, for this and other cases really good approximations are required and using the ‘\’ operator is not an option. For this situations iterative solver packages are the way to go, these contain a collection of methods which could be configured to accomplish better and more reliable approximations.
+
+Nevertheless, there isn’t yet a clear common API for these packages in Julia. In some cases when solving equations you would like to have just the approximation, in other cases however you would like more information about the convergence of the iterative process, like the residual norm of each iteration.
+
+There is one last case not present in most linear algebra packages, the ability to query information out of a running method, this would prove most useful when the calculation takes a long time, if it is bound to end at all. This could make the user to feel confused about what is going on and tempting him to end the execution.
+
+Here I show the current work and ideas aimed improve the usability of the IterativeSolvers.jl.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="ComputeFramework"><h3>ComputeFramework.jl - A framework and scheduler for parallel computing</h3></a>
+  <em>Shashi Gowda</em>
+  <p>ComputeFramework is a package that has a scheduler similar to that of Dask (dask.pydata.org) which minimizes memory footprint in parallel programs allowing processing of huge amounts of data even on a single machine with limited RAM.</p>
 </div>
 
 <div class="container abstrac">
@@ -255,60 +461,71 @@ In this talk I present our work on an improved API for Geodesy, showing how Juli
 </div>
 
 <div class="container abstrac">
-  <a name="Astrodynamics"><h3>Astrodynamics.jl: Modern Spaceflight Dynamics in Julia</h3></a>
-  <em>Helge Eichhorn</em> (Technische Universität Darmstadt, Germany)
-  <p>The motion of a spacecraft is governed by non-linear equations which makes numerical software tools indispensable for the development and operations of a space mission. Since the beginning of computational astrodynamics Fortran has been the language of choice due to the numerical performance requirements. Because Fortran is not exactly flexible and easy to work with many astrodynamicists use Matlab for prototyping algorithms. This has led to the familiar pattern of software tools being implemented twice, first in Matlab then in Fortran, or interfacing Matlab and Fortran through MEX-files and hundreds of lines of glue code.
+  <a name="ParallelAccelerator"><h3>A tour of ParallelAccelerator.jl</h3></a>
+  <em>Lindsey Kuper</em> (Intel Labs)
+  <p>Did you know that your Julia programs could be running much, much faster than they do now?  Recently, the High Performance Scripting team at Intel Labs released ParallelAccelerator.jl, a Julia package that leverages parallel compute resources (such as the multicore computer you probably already have on your desk) and compile-time and run-time optimizations to drastically speed up Julia programs, especially those that do lots of numeric array operations.
 
-In this talk I will present the Astrodynamics.jl library and explore how Julia’s unique feature set enables fast and easy modeling of complex space missions while not requiring expensive licenses or juggling multiple programming languages. With Julia it is possible to seamlessly move from simple approximations to parallel high-fidelity simulations which makes it an excellent choice for designing future space missions.</p>
+In this talk, we'll see some examples of how to use the ParallelAccelerator package, see what kind of speedups are possible, and then take a look at what ParallelAccelerator is doing under the hood.  Finally, we'll step back and discuss the future of parallelism in Julia.
+
+This talk will be of interest to people interested in compilers, macros, parallel computing, array- or vector-style programming, and anyone interested in making their Julia code run faster!</p>
 </div>
 
 <div class="container abstrac">
-  <a name="VinDsl"><h3>VinDsl.jl: Fast and furious statistical modeling</h3></a>
-  <em>John Pearson</em> (Duke Institute for Brain Sciences)
-  <p>Variational inference is a fast, scalable method for fitting complex statistical models to large and high-dimensional datasets. The repertoire of available algorithms and techniques is expanding rapidly, but most models are still coded by hand. The few automated implementations (e.g., in Stan) face a dual-language problem, and so are less suited to rapid development of new ideas. VinDsl.jl aims to provide a variational inference domain-specific language -- a set of data structures and macros for defining models -- in pure Julia. As a result, existing methods can be mixed and matched and new ones prototyped quickly, creating a thoroughly hackable toolbox for machine learning researchers. In this talk, I'll give an introduction to variational inference and sketch the philosophy and features of VinDsl, ending with applications to some problems in neuroscience.</p>
+  <a name="SimJulia"><h3>How to combine efficiently discrete-event and continuous-time simulations in Julia?</h3></a>
+  <em>Ben Lauwens</em> (Royal Military Academy (Belgium))
+  <p>Combined simulations, i.e. solving a mixture of discrete-events (implemented as processes or agents) and continuous-time models (systems of differential equations), is a challenging topic. The two paradigms are almost orthogonal and most simulation software is written with one specific purpose in mind. In this talk, I will show how both can fit naturally in the SimJulia.jl package. The differential equations are efficiently integrated with a quantized state system solver. The pitfall of the mainstream ODE solvers, the time discretization, is replaced by a state discretization. The resulting discrete state-machine can easily be implemented as an event-driven model. This allows to make and solve sophisticated models, eg. a pilot ejection system, which are otherwise very hard to do. Julia has some unique features that ease the coding of both the discrete-event kernel and the state quantizer. </p>
 </div>
 
 <div class="container abstrac">
-  <a name="LeastSquares"><h3>Least Squares with high dimensional variables</h3></a>
-  <em>Matthieu Gome</em>
-  <p>This talk would discuss various statistical models that require to solve sparse least square problems. I'll explain why these models are useful in social sciences, why they are hard to solve, and how to solve them in Julia.
+  <a name="FunctionalHPC"><h3>A functional approach to High Performance Computing</h3></a>
+  <em>Erik Schnetter</em> (Perimeter Institute for Theoretical Physics)
+  <p>High performance computing (HPC) on large distributed memory systems is today an irreplaceable tool in computational physics. To solve complex systems of partial differential equations (PDEs) such as e.g. the Einstein equations, today's discretization methods employ irregular grids and adaptive methods that are difficult to map onto modern HPC architectures in an efficient manner.
 
-I'll go through 2 examples:
-The first example is the class of linear regression models with high dimensional categorical variables. When there is a lot of groups, we simply cannot form the design matrix of all group dummies. I'll go though the best solution methods to solve these models, in term of speed, numerical stability, memory, &amp; standard errors.
-The solution method is available in the package: https://github.com/matthieugomez/FixedEffectModels.jl
-The package is an order of magnitude faster than similar packages in R or Stata. (The package is also the first Julia package that allows to estimate models with instrumental variables)
+FunHPC (Functional High Performance Computing) is both a promising proof of concept as well as an existing Julia package for scalable distributed computing. It is based on a partitioned global address spaces, latency hiding, ephemeral threads, and lightweight synchronization primitives.
 
-The second example is a PCA on a sparse panel. Think of the Netflix dataset: a user typically rates only a few movies so we have only a few non missing observations in the space user x movie. Estimating a PCA in this case requires to solve a sparse non linear least squares
-Relevant package:
-https://github.com/matthieugomez/SparseFactorModels.jl
-I don't know of a similar package in another language.
-
-Both of these packages use a general backend:
-https://github.com/matthieugomez/LeastSquaresOptim.jl
-This backend solves general sparse least square problems in Julia.</p>
+FunHPC targets PDE discretization methods with irregular, hierarchical data structures. I will describe the ideas behind and demonstrate an implementation of this approach via examples.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="APL"><h3>APL at Julia's speed</h3></a>
-  <em>Shashi Gowda</em>
-  <p>A look at why Julia is the best language to implement APL and how the JIT fares in the face of adversities. (https://github.com/shashi/APL.jl)
+  <a name="QuantumDynamics"><h3>QuDynamics - Framework for solving Dynamical Quantum Equations.</h3></a>
+  <em>Amit Jamadagni</em>
+  <p>QuDynamics is a Julia package which provides a framework for solving dynamical equations arising in Quantum Mechanics. The current version includes support for solving Schrodinger equations, Liouville von Neumann equations and Lindblad master equations with methods which have been integrated from various other Julia packages like ODE.jl, ExpmV.jl, Expokit.jl. The aim of the talk is to introduce QuDynamics with some examples, and focus on ongoing work to equip QuDynamics with additional features such as Monte-Carlo parallelization, addition of new solvers among many others. 
 
-- parsing examples https://github.com/shashi/APL.jl/blob/master/src/parser.jl
-- eval-apply https://github.com/shashi/APL.jl/blob/master/src/eval.jl
-- what's inside a function?
-- some @code_llvm samples
+The repo is being maintained at 
 
-see this gist for a demo https://gist.github.com/shashi/9ad9de91d1aa12f006c4</p>
+https://github.com/JuliaQuantum/QuDynamics.jl.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="CxxWrap"><h3>CppWrapper: Write Julia modules in C++</h3></a>
-  <em>Bart Janssens</em> (Royal Military Academy of Belgium)
-  <p>The CppWrapper package helps to expose C++ libraries as a Julia module. The  main difference with Cxx.jl is that the wrappers are in C++ and loaded into Julia as a shared library. This can be useful for large libraries, where the wrapping library can be precompiled. The wrapper can be bundled with the library, automatically ensuring it compiles when updating the C++ library.
+  <a name="BoundsChecks"><h3>Bounds check elimination in Julia v0.5</h3></a>
+  <em>Blake Johnson</em> (Raytheon BBN Technologies)
+  <p>Consistent with Julia's philosophy of having *both* performance and safety, it is important to have bounds checks on array accesses by default, as well as a means to eliminate such checks when the compiler or user can prove that they are unnecessary. Julia v0.5 introduces a new mechanism for user-extensible bounds checking and elimination via simple call-site decoration. In this talk, I will discuss the design approach and show off some of the internals of the implementation. Finally, I will show how to take advantage of this new feature for custom array types.</p>
+</div>
 
-In this talk, first the use of the package will be illustrated with a simple example. Next, some aspects of the implementation will be highlighted. The package is based on a combination of ccall and embedded use of the Julia C interface, so this will be explained in detail. On the Julia side, some metaprogramming techniques -used to generate methods- will be shown.
+<div class="container abstrac">
+  <a name="MatrixNetworks"><h3>Network Algorithms Research in Julia</h3></a>
+  <em>Huda Nassar</em> (Purdue University)
+  <p>Datasets in many research disciplines involve large networks; examples include biological datasets, transportation networks, and social media networks. In this talk, we will describe how we are using Julia in our research into new network algorithms and why we created the MatrixNetworks.jl package to bridge between the linear algebra routines in Julia and the network algorithms. We will discuss algorithms that we have recently created for graph diffusions and network alignment methods where having methods that interface between these representations is essential. </p>
+</div>
 
-In summary, this talk is targeted at people who are interested in wrapping C++ libraries, want to use the Julia C interface (embedding) or see an example of metaprogramming to define new methods.</p>
+<div class="container abstrac">
+  <a name="Yeppp"><h3>High Performance Vectorized Computations with Yeppp!</h3></a>
+  <em>Robert Guthrie</em> (Georgia Institute of Technology)
+  <p>In this talk, we present Yeppp!, a high-performance mathematical library providing vectorized elementary operations and transcendental functions.  We compare the performance of Yeppp! with libraries such as Intel MKL and code generated by the optimizing compilers LLVM and GCC.  We demonstrate that the SIMD-vectorization and software pipelining techniques used in Yeppp! permit higher throughput compared to similar offerings, and we directly compare implementations of element-wise floating point addition in unoptimized assembly, code generated by LLVM and GCC, and Yeppp!.  The experiments reveal that Yeppp!’s implementation outperforms alternative implementations.  </p>
+</div>
+
+<div class="container abstrac">
+  <a name="BaseTestAuto"><h3>Finding Julia Bugs Automatically</h3></a>
+  <em>Robert Feldt</em> (Blekinge Inst of Technology)
+  <p>The ability to thoroughly, but easily, test Julia code and packages is vital if they are to maintain their high quality. The Base.Test framework provides a great set of constructs to help automatically execute test cases and avoid bugs. Recently we have extended this framework with award-winning techniques from our software testing research. Together, these packages enable not only the automated execution but also the automated creation of test cases. This can help you explore the actual behavior of your Julia code to find bugs earlier and increase coverage. In this talk we give an overview of the techniques our extensions provide, and show, with examples, how they have helped us find bugs in Julia code.
+
+Our extensions combine the novel capabilities of a number of different testing frameworks, programming languages and research studies. The BaseTestAuto package provides the basis by extending the Base.Test implementation in Julia 0.5-dev to support repeated execution of test sets and to allow predicates that ensure not only a single but that a whole set of values have a certain property. Another package allows generators for values of any type and structure to be described; this allows for both random and targetted creation of test data. On top of this we can then build a library of generators and combinators to create data that exercises a large part of the Julia type hierarchy. Together these packages extend the type of testing that can now be done in Julia, and in our presentation we will demonstrate random testing, property-based testing, parameterized unit testing, adaptive test execution, and search-based testing for increased coverage and test diversity. Our talk is hands-on and shows the use of these techniques on real Julia code but also outlines future additions that we are working on. Our mission is to make testing in Julia as fun and powerful as possible and we hope to get support from the community in achieving this.</p>
+</div>
+
+<div class="container abstrac">
+  <a name="ArrayFire"><h3>Accelerating Julia Kernels with ArrayFire</h3></a>
+  <em>Ranjan Anantharaman</em>
+  <p>Accelerated computing has become increasingly popular in the scientific community over the past few years. However, a common challenge is the dearth of easy high-level APIs. This talk is about using the package ArrayFire.jl to write accelerated kernels in Julia with easy Julian APIs. It is designed to mimic Base Julia in its versatility and ease of use, and allows you to switch between three backends: CPU, OpenCL and CUDA, without changing any code. This talk would demonstrate those capabilities and interesting applications using ArrayFire.</p>
 </div>
 
 <div class="container abstrac">
@@ -319,108 +536,17 @@ Demonstrate how can interactive debugging, scripting with Julia for iOS App deve
 </div>
 
 <div class="container abstrac">
-  <a name="RobotNavigation"><h3>Towards a nonparametric belief solution for factor graphs</h3></a>
-  <em>Dehann Fourie</em> (MIT/WHOI Joint Program)
-  <p>We relax parametric inference to a non-parametric representation over the Bayes tree, towards more general factor graph solutions. We use Gaussian Mixture models to represent a wider class of constraint beliefs, including multi-hypothesis inference. The Bayes tree factorization maximally exploits the structure of the true joint posterior, thereby minimizing computation. We use approximate non-parametric belief propagation over the cliques of the Bayes tree to reduce the computational complexity. Robotic navigation and mapping is our focused application. Our implementation has been written entirely in the Julia language, exploiting high performance and parallel computing.</p>
+  <a name="PETSc"><h3>PETSc.jl: Interfacing an enormous C sparse-matrix library</h3></a>
+  <em>Jared Crean</em> (Rensselaer Polytechnic Institute)
+  <p>There exist many well-establish scientific libraries written C and Fortran which, taken together, form a software stack that supports high performance applications. This talk describes the wrapping of the Portable Extensible Toolkit for Scientific Computation (PETSc), a library for solving sparse linear and non-linear problems, such as those that arise from discretizing partial differential equations, on distributed memory systems. With 3,674 functions defined in its header files, wrapping the library is a significant challenge. The Clang.jl package is used to generate Julia Exprs for the C functions, which are then modified by a re-writer function to a more Julian form. In order to support matrices containing real and complex data, the package builds and links to 3 versions of PETSc simultaneously. To present the user with a unified interface, new Vector and Matrix types are defined that present the AbstractArray interface and contain additional functionality such as control over assembly of distributed-memory data structures and mapping local indices to global indices. Similarly, the iterative solver interface supports default usage as an A \ b solver, but also contains a wide variety of options for pre-conditioning and the choice of Krylov method. An overview of the present state of the wrappers and future work will be given.</p>
 </div>
 
 <div class="container abstrac">
-  <a name="BoundedIntegers"><h3>Bounded Integers with Type-Level Constants </h3></a>
-  <em>David Hossack</em> (Analog Devices)
-  <p>I will describe the implementation of a bounded integer type in Julia, where the bounds are encoded as type level constants.  All the usual arithmetic operations on integers are implemented with the result bounds being determined once at (JIT) compile time.  For example adding bounded integers with types BInt{-10,8} and BInt{-100, 20} will yield a bounded integer with type BInt {-110, 28}.
+  <a name="Lora"><h3>Lora: a framework for Monte Carlo methods in Julia</h3></a>
+  <em>Theodore Papamarkou</em>
+  <p>Lora is a package for Monte Carlo methods in Julia. The package has been supporting geometric MCMC algorithms for the last two years. It has been refactored over the last six months to allow more efficient memory management and execution time by allocating necessary resources at the beginning of the simulation thus avoiding unnecessary reallocations and by using meta-programming to tailor methods to user-defined simulation settings. Furthermore, graphs are used for model specification, Gibbs sampling has been accommodated, output management has been improved and forward as well as reverse mode automatic differentiation capabilities have been added to MCMC samplers.
 
-The bounds can be any constant integer, and large bounds are automatically converted to a tuple format that allows extremely large (effectively unbounded) integers to be represented at the type level despite Julia’s current limitation that the type parameter be a “bits type”.  The appropriate value type is determined from the bounds - this can be Int32, Int64, Int128 or BigInt as required.
-
-The implementation exploits @generated functions to make the type level decisions.
-
-The original motivation arose in digital hardware system modeling, but the concept is very general.  The bounded integer “BInt” numeric type behaves like BigInt in that arithmetic on BInt values will never overflow, but without the runtime and storage overhead of BigInt when it can be determined that a fixed width type is sufficient.
-</p>
-</div>
-
-<div class="container abstrac">
-  <a name="GLVisualize"><h3>Current state of GLVisualize </h3></a>
-  <em>Simon Danisch</em>
-  <p>GLVisualize is a 2D/3D graphics library entirely written in Julia. It uses OpenGL to offer state of the art rendering speeds even for animated data. This Talk will show you what the strength and weaknesses of GLVisualize are, and what you can expect from it in the future.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="DataStreams"><h3>DataStreams: Workflows for Data Processing Tasks</h3></a>
-  <em>Jacob Quinn</em> (Domo)
-  <p>Julia's core language performance has attracted developers for years. In terms of standardized data processing tasks, however, Julia has lagged peer tools in terms of functionality and convenience. The DataStreams package and framework aims to bring foundational tools and workflows to Julia that encourage interface consistency and automatic leveraging of Julia's built-in performance levers. The CSV, SQLite, and ODBC packages currently implement the DataStreams framework to provide foundational data processing tools for Julia data mungers.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="OnlineStats"><h3>OnlineStats.jl: Statistics for Streaming and Big Data</h3></a>
-  <em>Josh Day</em> (NC State University)
-  <p>Statistical algorithms are typically based around data fixed in size.  Adapting methods to data which is streaming or too large to fit in memory is often nontrivial.  OnlineStats.jl provides a state of the art toolkit for performing statistical analysis in these situations.  All algorithms use O(1) memory and stochastic approximations are used where analytical solutions are not possible.  The methods provided by OnlineStats.jl include summary statistics, density estimation, statistical learning, and more.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="SimJulia"><h3>How to combine efficiently discrete-event and continuous-time simulations in Julia?</h3></a>
-  <em>Ben Lauwens</em> (Royal Military Academy (Belgium))
-  <p>Combined simulations, i.e. solving a mixture of discrete-events (implemented as processes or agents) and continuous-time models (systems of differential equations), is a challenging topic. The two paradigms are almost orthogonal and most simulation software is written with one specific purpose in mind. In this talk, I will show how both can fit naturally in the SimJulia.jl package. The differential equations are efficiently integrated with a quantized state system solver. The pitfall of the mainstream ODE solvers, the time discretization, is replaced by a state discretization. The resulting discrete state-machine can easily be implemented as an event-driven model. This allows to make and solve sophisticated models, eg. a pilot ejection system, which are otherwise very hard to do. Julia has some unique features that ease the coding of both the discrete-event kernel and the state quantizer. </p>
-</div>
-
-<div class="container abstrac">
-  <a name="Yeppp"><h3>High Performance Vectorized Computations with Yeppp!</h3></a>
-  <em>Robert Guthrie</em> (Georgia Institute of Technology)
-  <p>In this talk, we present Yeppp!, a high-performance mathematical library providing vectorized elementary operations and transcendental functions.  We compare the performance of Yeppp! with libraries such as Intel MKL and code generated by the optimizing compilers LLVM and GCC.  We demonstrate that the SIMD-vectorization and software pipelining techniques used in Yeppp! permit higher throughput compared to similar offerings, and we directly compare implementations of element-wise floating point addition in unoptimized assembly, code generated by LLVM and GCC, and Yeppp!.  The experiments reveal that Yeppp!’s implementation outperforms alternative implementations.  </p>
-</div>
-
-<div class="container abstrac">
-  <a name="Escher"><h3>Patterns for building web apps with Escher.jl</h3></a>
-  <em>Shashi gowda</em>
-  <p>The talk is about component architecture in Escher.jl. I aim to describe how to build arbitrarily complex web apps from smaller components using a model-view-update pattern.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="WordEmbeddings"><h3>Fun with Word Embeddings in Julia</h3></a>
-  <em>Sisir Koppaka</em> (Data Scientist, x.ai)
-  <p>Word embeddings allow us to represent words, phrases, and even sentences as vectors in a hyperspace. This helps us in better capturing syntactic and semantic similarities between natural language entities based on distributional properties of various corpora. I'll briefly introduce the idea, and step visually into the process with a pure-Julia implementation. The backdrop of the discussion will be a year of practical learnings on shortening the feedback loop in ML at a fast-pace ML/NLP-driven startup.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="GWAS"><h3>A novel algorithm for model selection in genome-wide association studies</h3></a>
-  <em>Kevin L. Keys</em> (University of California, Los Angeles)
-  <p>Genome-wide association studies (GWASes) examines phenotypic variation in a sample of patients genotyped at several places on the genome. Since GWASes were introduced in 2005, researchers have performed GWASes for hundreds of traits on thousands of individuals. GWASes produce massive quantities of data that present computational and model selection challenges to their analysis. Prevalent among GWAS analyses is a noticeable failure to explain substantial portions of the observed phenotypic variance. We exploit iterative hard thresholding (IHT) to effectively select genetic markers informative for continuous traits. Preliminary tests suggest that our implementation effectively controls type I errors better than both LASSO- and MCP-penalized linear regression. Our scalable implementation enables GWAS analysis on both desktop machines and computing clusters.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="DSGE"><h3>DSGE.jl – Using Julia for Economic Modeling at the Federal Reserve Bank of New York </h3></a>
-  <em>Erica Moszkowski</em> (Federal Reserve Bank of New York)
-  <p>This talk will describe how researchers in the Federal Reserve Bank of New York’s DSGE Team use Julia for macroeconomic modeling.  In collaboration with the QuantEcon team, we ported our code for solving dynamic stochastic general equilibrium (DSGE) models to Julia, releasing the source code in the DSGE.jl package in December. DSGE models describe how economic agents behave, given some assumptions about the underlying environment, including fiscal and monetary policy regimes, price rigidities, credit frictions, and various economic shocks.  The FRBNY model is a relatively large model of the U.S. economy, has been used for research on the dynamics of inflation during the great recession, the effects of forward guidance, and much more.
-
-The DSGE.jl package facilitates the solution and Bayesian estimation of DSGE models. We provide the FRBNY model as one example, but give details on how users can define completely different models.  In this talk, I will give a brief overview of the model and our experience porting the code from MATLAB to Julia (including perspective on using Julia in a "production" setting at a public policy institution). Finally, I will touch on the Julia features our team has found most useful for economic modeling</p>
-</div>
-
-<div class="container abstrac">
-  <a name="TwoCultures"><h3>The Two Cultures of Programming</h3></a>
-  <em>Joshua Ballanco</em>
-  <p>In 1959 C.P. Snow's famous lecture, "The Two Cultures", decried the failure of educated people in the sciences and humanities to work together. Today we have a similar divide opening between those who write software for science and those who write it for "everything else". In this talk, we'll review the current state of affairs and look at what Julia might do to remedy the situation. The hope is that Julia can be a great programming language not just for science, but for programmers everywhere.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="JuliaBox"><h3>Overview of the new JuliaBox</h3></a>
-  <em>Nishanth</em>
-  <p>JuliaBox is currently hosted on AWS but will be hosted on Google cloud in the future. This talk gives the necessary information needed for users to migrate their data. The new features available for free/paid users and the road map for future development will also be presented.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="ForwardRoots"><h3>Enabling reverse communication solvers and embedding Julia</h3></a>
-  <em>Andy Greenwell</em> (Julia Computing, Inc.)
-  <p>This talk provides an overview of a consulting project that had two primary goals: 1. Enable the modification of various forward communication root finding and optimization solvers available in the Julia ecosystem to be used as reverse communication solvers, wherein any objective, gradient, or Hessian functions can be evaluated external to the solver itself.  2. Allow for embedding of the Julia solver within a C/C++ application where the objective, gradient and Hessian functions are defined as part of a large pre-existing codebase.  This talk will walk through the specific Julia functionality necessary to enable a variety of forward communication solvers available in different Julia packages to be called in a reverse communication manner, and show how this functionality can be embedded within a C/C++ application.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="IterativeMethods"><h3>Iterative Methods for  Sparse Linear Systems in Julia: A Quick Overview</h3></a>
-  <em>Lars Ruthotto</em> (Emory University)
-  <p>Efficient iterative methods for sparse linear systems are crucial in many research and industrial applications, for example, for solving partial differential equations (PDEs). There are different Julia packages that provide implementations of many state-of-the-art linear methods. In this lightning talk, I will give an overview about some of the packages and highlight similarities and differences in coding philosophy. I will also give a detailed comparison of their computational efficiency of  using examples from numerical PDEs. The main goal of the talk is to start a discussion about the inevitable trade-offs between computational efficiency, ease of use and readability of the code.</p>
-</div>
-
-<div class="container abstrac">
-  <a name="MusicIR"><h3>Music Information Retrieval in Julia</h3></a>
-  <em>Jong Wook Kim</em> (New York University)
-  <p>Music Information Retrieval (MIR) is an exciting field of research with many successful real-world applications, such as automatic audio source separation, instrument recognition, chord recognition, automatic transcription and music recommender systems. In this lightning talk, I will briefly introduce MIR as a research topic, and show how Julia can be used to perform various music analysis and processing required in MIR research. The presentation will also include a demo of audio visualization and instrument classification, based on a music analysis library written in Julia that is planned to be open sourced by JuliaCon 2016.</p>
+The roadmap of Lora includes adding documentation for existing functionality, capabilities for state of the art Monte Carlo integration, sequential and variational Monte Carlo algorithms, and other parallel-based MCMC sampling schemes. The overarching goal is to turn Lora into a powerful framework that can be used for tackling challenging applied problems. Along these lines, a contract has been signed with Springer to author a book on Monte Carlo methods with Julia (using Lora), and a collaboration with NASA has been set up for using MCMC inference for exoplanet discovery. Such collaboration will be particularly useful because it entails complex models with constrained parameters, so it will provide further feedback to help Lora meet the challenges of non-trivial applications.</p>
 </div>
 
 <!-- OKAY TO EDIT PAST HERE -->

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@ title: JuliaCon
   <h2 class="text-center border-header"><span>Schedule</span></h2>
     <table style="border: 10; border-spacing: 10px; ">
     <tr><td>Tuesday, June 21  </td> <td><a href="workshops.html#tuesday">Workshops </a></td>
-    <tr><td>Wednesday-Friday, June 22-24  </td> <td><a href="abstracts.html">Talks         </td>
-    <tr><td>Saturday, June 25 </td> <td>                                 Hackathon     </td>
+    <tr><td>Wednesday-Friday, June 22-24  </td> <td><a href="schedule.html">Talks         </td>
+    <tr><td>Saturday, June 25 </td> <td>                                    Hackathon     </td>
     </table>
     </center>
 </div>

--- a/schedule.html
+++ b/schedule.html
@@ -1,0 +1,256 @@
+---
+layout: default
+title: JuliaCon Talk Schedule
+---
+
+<style>
+  .border-header a {
+    text-decoration: none;
+  }
+</style>
+
+<div class="schedule-table">
+<h2 class="text-center border-header"><span>Talk Schedule</span></h2>
+Please see <A href="workshops.html">here</a> for Tuesday workshop schedule.
+
+<!-- DO NOT EDIT TABLE. EDIT .csv FILES and REGENERATE TABLE WITH gen.jl -->
+<table>
+  <tr>
+    <th>Wednesday</th><th>Track 1</th><th>Track 2</th>
+  </tr>
+  <tr>
+    <td>8:30</td><td>Opening remarks</td><td></td>
+  </tr>
+  <tr>
+    <td>8:40</td><td>Guy Steele (invited talk)</td><td></td>
+  </tr>
+  <tr>
+    <td>9:30</td><td><a href="abstracts.html#Gallium">Gallium</a></td><td></td>
+  </tr>
+  <tr>
+    <td>10:00</td><td><a href="abstracts.html#Juno">Juno, a Julia IDE</a></td><td></td>
+  </tr>
+  <tr>
+    <td>10:10</td><td>MORNING BREAK</td><td></td>
+  </tr>
+  <tr>
+    <td>10:40</td><td><a href="abstracts.html#RataJulia">  Rata Julia: video tracking for behavioural neuroscience with Julia</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#DataScience">Julia for data science: current progress and future plans</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#DataTables">DataTables: Type-safe data containers</a></td><td></td>
+  </tr>
+  <tr>
+    <td>12:00</td><td>A WORD FROM SPONSORS (Moore, Invenia)</td><td></td>
+  </tr>
+  <tr>
+    <td>12:15</td><td>LUNCH</td><td></td>
+  </tr>
+  <tr>
+    <td>13:30</td><td><a href="abstracts.html#JuMP">Automatic differentiation techniques used in JuMP</a></td><td><a href="abstracts.html#GLVisualize">Current state of GLVisualize </a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ForwardDiff">ForwardDiff.jl: Fast Derivatives Made Easy</a></td><td><a href="abstracts.html#Vulkan">Introduction to Vulkan</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td><a href="abstracts.html#ThreeJS">ThreeJS.jl: Interactive 3D Graphics in the Browser using Julia</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td><a href="abstracts.html#NetworkViz">NetworkViz.jl - A Julia interface to visualize graphs using ThreeJS.jl.</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ForwardRoots">Enabling reverse communication solvers and embedding Julia</a></td><td><a href="abstracts.html#GR">State of the GR framework</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#IterativeMethods">Iterative Methods for  Sparse Linear Systems in Julia: A Quick Overview</a></td><td><a href="abstracts.html#Escher">Patterns for building web apps with Escher.jl</a></td>
+  </tr>
+  <tr>
+    <td>15:10</td><td>EVENING BREAK</td><td></td>
+  </tr>
+  <tr>
+    <td>15:40</td><td><a href="abstracts.html#VinDsl">VinDsl.jl: Fast and furious statistical modeling</a></td><td><a href="abstracts.html#Unums2.0">Unums 2.0: Implementing projective intervals and sets in Julia</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#RCall">Julia and R: Can't we have both?</a></td><td><a href="abstracts.html#ExtendedFloats">The design and use of extended precision floats</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#CxxWrap">CppWrapper: Write Julia modules in C++</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#APL">APL at Julia's speed</a></td><td><a href="abstracts.html#India">Building the Julia community in India</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#FrequonInvaders">Using Julia as a Quick and Dirty Code Generator</a></td><td><a href="abstracts.html#BoundedIntegers">Bounded Integers with Type-Level Constants </a></td>
+  </tr>
+  <tr>
+    <td>17:05</td><td></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td></td>
+  </tr>
+  <tr>
+    <th>Thursday</th><th>Track 1</th><th>Track 2</th>
+  </tr>
+  <tr>
+    <td>8:45</td><td>Tim Holy (invited talk)</td><td></td>
+  </tr>
+  <tr>
+    <td>9:35</td><td><a href="abstracts.html#Julia1.0">Julia 1.0</a></td><td></td>
+  </tr>
+  <tr>
+    <td>10:10</td><td>MORNING BREAK</td><td></td>
+  </tr>
+  <tr>
+    <td>10:40</td><td><a href="abstracts.html#RaceCars">Autonomous driving for RC cars with ROS and Julia</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#RaspberryPi">Minecraft and LEDs : Julia on the Raspberry Pi</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#JuliaBox">Overview of the new JuliaBox</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#TeachingJulia">Teaching first-year college students with Julia</a></td><td></td>
+  </tr>
+  <tr>
+    <td>12:00</td><td>A word from sponsors (Intel, Julia Computing)</td><td></td>
+  </tr>
+  <tr>
+    <td>12:15</td><td>LUNCH</td><td></td>
+  </tr>
+  <tr>
+    <td>13:30</td><td><a href="abstracts.html#HPAT">HPAT.jl - Easy and Fast Big Data Analytics</a></td><td><a href="abstracts.html#PDEs">Julia and Partial Differential Equations: Being Faster than M*TL*B</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#OnlineStats">OnlineStats.jl: Statistics for Streaming and Big Data</a></td><td><a href="abstracts.html#FiniteElementAnalysis">Finite Element Analysis in Julia</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#DataStreams">DataStreams: Workflows for Data Processing Tasks</a></td><td><a href="abstracts.html#Astrodynamics">Astrodynamics.jl: Modern Spaceflight Dynamics in Julia</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td></td>
+  </tr>
+  <tr>
+    <td>15:20</td><td>EVENING BREAK</td><td></td>
+  </tr>
+  <tr>
+    <td>15:40</td><td><a href="abstracts.html#LeastSquares">Least Squares with high dimensional variables</a></td><td><a href="abstracts.html#GWAS">A novel algorithm for model selection in genome-wide association studies</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ValidatedNumerics">Precise and rigorous calculations for dynamical systems</a></td><td><a href="abstracts.html#OpenMendel">OpenMendel Project</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td><a href="abstracts.html#MusicIR">Music Information Retrieval in Julia</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td><a href="abstracts.html#WordEmbeddings">Fun with Word Embeddings in Julia</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#RobotNavigation">Towards a nonparametric belief solution for factor graphs</a></td><td></td>
+  </tr>
+  <tr>
+    <td>17:05</td><td></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td></td>
+  </tr>
+  <tr>
+    <th>Friday</th><th>Track 1</th><th>Track 2</th>
+  </tr>
+  <tr>
+    <td>8:45</td><td>Tom Sargent (invited talk)</td><td></td>
+  </tr>
+  <tr>
+    <td>9:35</td><td><a href="abstracts.html#DSGE">DSGE.jl – Using Julia for Economic Modeling at the Federal Reserve Bank of New York </a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td></td>
+  </tr>
+  <tr>
+    <td>10:10</td><td>MORNING BREAK</td><td></td>
+  </tr>
+  <tr>
+    <td>10:40</td><td><a href="abstracts.html#BioJulia">BioJulia: Towards Bioinformatics in the Real World</a></td><td><a href="abstracts.html#TwoCultures">The Two Cultures of Programming</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#GraphLayout">Backend Agnostic GraphLayout.jl</a></td><td><a href="abstracts.html#MachineCode">Machine Code</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ParallelGraph">Parallelized graph processing in Julia</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#Vectorize">Cross-platform vectorization using Accelerate, Yeppp! and VML</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#HTTP2">Implementing HTTP/2 for Julia</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#InterTut">Julia Interactive Tutorial System</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#Documenter">Documenting Julia packages</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#Convex">Support for complex-domain optimization problems in Convex.jl</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#Presolve">Presolve Routines for Optimization Problems</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ODE">A Review of a Recently Implemented Implicit and Adaptive ODE Solver based on Adam-Bashforth-Multon Methods</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#Images">Exposure Correction and Feature Extraction with Images.jl</a></td><td></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ProgQuery">When is my calculation done? Programmatic query for the status of long calculations</a></td><td></td>
+  </tr>
+  <tr>
+    <td>12:00</td><td>A word from sponsors (Conning, Jeffrey Sarnoff)</td><td></td>
+  </tr>
+  <tr>
+    <td>12:15</td><td>LUNCH</td><td></td>
+  </tr>
+  <tr>
+    <td>13:30</td><td><a href="abstracts.html#ComputeFramework">ComputeFramework.jl - A framework and scheduler for parallel computing</a></td><td><a href="abstracts.html#Geodesy">Accurate 3D mapping with Geodesy and Proj4</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ParallelAccelerator">A tour of ParallelAccelerator.jl</a></td><td><a href="abstracts.html#SimJulia">How to combine efficiently discrete-event and continuous-time simulations in Julia?</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#FunctionalHPC">A functional approach to High Performance Computing</a></td><td><a href="abstracts.html#QuantumDynamics">QuDynamics - Framework for solving Dynamical Quantum Equations.</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#BoundsChecks">Bounds check elimination in Julia v0.5</a></td><td><a href="abstracts.html#MatrixNetworks">Network Algorithms Research in Julia</a></td>
+  </tr>
+  <tr>
+    <td>15:10</td><td>EVENING BREAK</td><td></td>
+  </tr>
+  <tr>
+    <td>15:40</td><td><a href="abstracts.html#Yeppp">High Performance Vectorized Computations with Yeppp!</a></td><td><a href="abstracts.html#BaseTestAuto">Finding Julia Bugs Automatically</a></td>
+  </tr>
+  <tr>
+    <td></td><td><a href="abstracts.html#ArrayFire">Accelerating Julia Kernels with ArrayFire</a></td><td><a href="abstracts.html#Swifter">Swifter.jl : Scripting, REPL for iOS App development</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td><a href="abstracts.html#PETSc">PETSc.jl: Interfacing an enormous C sparse-matrix library</a></td>
+  </tr>
+  <tr>
+    <td></td><td></td><td><a href="abstracts.html#Lora">Lora: a framework for Monte Carlo methods in Julia</a></td>
+  </tr>
+  <tr>
+    <td>17:05</td><td>Closing remarks</td><td></td>
+  </tr>
+  <tr>
+    <td>17:15</td><td></td><td></td>
+  </tr>
+</table>
+<!-- OKAY TO EDIT PAST HERE -->
+</div>
+
+<div class="abstrac"><a href="index.html"><center>JuliaCon 2016 Home Page</center></a></div>

--- a/schedule.html
+++ b/schedule.html
@@ -43,7 +43,7 @@ Please see <A href="workshops.html">here</a> for Tuesday workshop schedule.
     <td></td><td><a href="abstracts.html#DataTables">DataTables: Type-safe data containers</a></td><td></td>
   </tr>
   <tr>
-    <td>12:00</td><td>A WORD FROM SPONSORS (Moore, Invenia)</td><td></td>
+    <td>12:00</td><td>A word from sponsors (Moore, Invenia)</td><td></td>
   </tr>
   <tr>
     <td>12:15</td><td>LUNCH</td><td></td>

--- a/workshops.html
+++ b/workshops.html
@@ -13,8 +13,10 @@ title: JuliaCon Workshops
   <h2 class="text-center border-header"><span>Workshops</span></h2>
   <center>
   <table>
+    <tr><th>Morning</th></tr>
     <tr><td><a href="#invitation">Invitation to Intermediate-Level Julia</a></td></tr>
     <tr><td><a href="#performance">Introduction to Writing High Performance Julia</a></td></tr>
+    <tr><th>Afternoon</th></tr>
     <tr><td><a href="#plots">Plots with Plots</a></td></tr>
     <tr><td><a href="#binary_dependencies">Creating, Distributing, and Testing Julia Packages with Binary Dependencies</a></td></tr>
     <tr><td><a href="#parallel">Parallel computing with Julia</a></td></tr>


### PR DESCRIPTION
This PR adds the tentative schedule for talks.  It also indicate which workshops are in morning or afternoon.

**Do we have confirmation** from Guy Steele and TIm Holy on which days they are talking?

Abstracts reordered to be consistent with schedule.  Unfortunately the current `gen.jl` interleaves them in the two-track situation.  Fixing that can wait for another day.