### PR TITLE
add keynote talk titles

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -7,7 +7,7 @@
     <td class=time>8:30</td><td>Opening remarks</td><td></td>
   </tr>
   <tr>
-    <td class=time>8:40</td><td>Guy Steele (invited talk)</td><td></td>
+    <td class=time>8:40</td><td>Guy Steele (invited talk): Fortress Features and Lessons Learned</td><td></td>
   </tr>
   <tr>
     <td class=time>9:30</td><td><a href="abstracts.html#Gallium">Gallium</a></td><td></td>
@@ -82,7 +82,7 @@
     <th>Thursday</th><th>Track 1</th><th>Track 2</th>
   </tr>
   <tr>
-    <td class=time>8:45</td><td>Tim Holy (invited talk)</td><td></td>
+    <td class=time>8:45</td><td>Tim Holy (invited talk): To the curious incident of the CPU in the run-time: an overview of arrays and iteration in Julia</td><td></td>
   </tr>
   <tr>
     <td class=time>9:35</td><td><a href="abstracts.html#Julia1.0">Julia 1.0</a></td><td></td>
@@ -139,7 +139,7 @@
     <th>Friday</th><th>Track 1</th><th>Track 2</th>
   </tr>
   <tr>
-    <td class=time>8:45</td><td>Tom Sargent (invited talk)</td><td></td>
+    <td class=time>8:45</td><td>Tom Sargent (invited talk): Quantitative Macroeconomics</td><td></td>
   </tr>
   <tr>
     <td class=time>9:35</td><td><a href="abstracts.html#DSGE">DSGE.jl – Using Julia for Economic Modeling at the Federal Reserve Bank of New York</a></td><td></td>


### PR DESCRIPTION
@ArchRobison I attempted to edit `schedules.csv` in the JuliaCon2016 repo and regenerate `schedules.html` as per the instructions, but got the following `convert` error:
```
➜  Schedule git:(master) ✗ julia -f gen.jl
ERROR: LoadError: MethodError: `convert` has no method matching convert(::Type{Array{Any,1}}, ::Array{Any,2})

You might have used a 2d row vector where a 1d column vector was required.
Note the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].
You can convert to a column vector with the vec() function.
This may have arisen from a call to the constructor Array{Any,1}(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert{T}(::Type{Array{T,1}}, !Matched::Range{T})
  convert{T,S,N}(::Type{Array{T,N}}, !Matched::SubArray{S,N,P<:AbstractArray{T,N},I<:Tuple{Vararg{Union{AbstractArray{T,1},Colon,Int64}}},LD})
  ...
 in setindex! at dict.jl:641
 in add! at /Users/jarrettrevels/data/repos/JuliaCon2016/Schedule/gen.jl:29
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in process_options at ./client.jl:280
 in _start at ./client.jl:378
while loading /Users/jarrettrevels/data/repos/JuliaCon2016/Schedule/gen.jl, in expression starting on line 132
```

This PR reflects the changes I'd like to make, we can either backport them, or figure out how to properly regenerate the HTML from the CSV - whatever's easier.