### PR TITLE
Add automatic build and deployment of the JuliaCon website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: ruby
+
+cache: bundler
+
+rvm:
+  - 2.4
+
+branches:
+  only:
+    - master
+
+before script:
+
+install:
+  - gem install jekyll
+  - gem install html-proofer
+
+
+script:
+  - bash script/build.sh
+
+sudo: false
+
+env:
+  global:
+  - secure:
+  #need to add the Travis encrypted data here
+
+  
+exclude: [vendor]
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: "$GH_TOKEN"
+  local_dir: ./_site
+  target_branch: gh-pages
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -7,5 +7,22 @@ For local development install jekyll and run `jekyll serve` from the repository 
 
 ## Automatic build and deployment of the site
 The source for the Jekyll website is currently located in the `master` branch of this repository.
+The built site will be deployed to `gh-pages`. This will be triggered when a push is made to the `master` branch. Push and PR to other branches should not trigger any build and deployment of the site.
 
 The build and deployment of the site to GitHub pages is done using Travis CI.
+
+### Install and enable Travis CI
+
+1. [Enable Travis CI](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI) for this repository
+2. Generate a [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) so that Travis can commit the built site to `gh-pages`
+3. Install Travis CLI locally by running
+```bash
+gem install travis
+```
+4. Create an encrypted environment variable using the GitHub personal access token created in step 2.In your terminal type:
+```bash
+travis encrypt 'GH_USER=<your username>' 'GH_EMAIL=<your email>' 'GH_TOKEN=<your token>' --add
+```
+This will encrypt your sensitive information and add it automatically to the .travis.yml file in the repository.
+5. Ensure the site is being served from the `gh-pages` branch (you can check this in the repository settings)
+6. All set. 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ juliacon.github.io
 http://juliacon.org/
 
 For local development install jekyll and run `jekyll serve` from the repository root. Old Jekyll based sites are build with `jekyll build --source YYYYsrc --destination YYYY`.
+
+## Automatic build and deployment of the site
+The source for the Jekyll website is currently located in the `master` branch of this repository.
+
+The build and deployment of the site to GitHub pages is done using Travis CI.

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,8 @@
+#!bin/bash
+
+# Build with Jekyll into "_site"
+jekyll build --config _config.yml --source . --destination ./_site
+
+# Using htmlproofer to test the _site
+# currently checking for links, and 4xx errors might need to add check images
+htmlproofer ./site --disable-external --only_4xx


### PR DESCRIPTION
This PR should solve the incompatibility problem between the currently used plugins and GitHub pages. 
This is done by triggering automatic builds and deploys of the website from Travis Ci. 
Major changes:
1. Addition of  .travis.yml  to enable the automatic build and deployment
2. Add build script which will also test the website before deployment
3. Add information on this enahncement to the README.md file