### PR TITLE
add workshops to the site

### DIFF
--- a/2018/all_talks.html
+++ b/2018/all_talks.html
@@ -4,7 +4,10 @@ layout: default2018
 {% assign img_folder = "assets/img" %}
 {% assign talks = site.data.2018_talks_workshops %}
 
-{% include grey_nav.html %}
+{% include earlybird.html %}
+{% include header18.html %}
+{% include main_nav.html %}
+
 <div class="u-vskip-3"></div>
 
 {% include talks_menu.html %}

--- a/2018/assets/css/style.css
+++ b/2018/assets/css/style.css
@@ -467,7 +467,7 @@ ul, ol {
     font-weight: 700;
     display: block;
     margin-left: 100pt;
-    margin-top: -85pt;
+    margin-top: -80pt;
     max-width: 80%;
 }
 .content-box .speaker-talks {

--- a/2018/lightning_talks.html
+++ b/2018/lightning_talks.html
@@ -4,7 +4,9 @@ layout: default2018
 {% assign img_folder = "assets/img" %}
 {% assign talks = site.data.2018_talks_workshops | where:'type', 'lightning_talk' %}
 
-{% include grey_nav.html %}
+{% include earlybird.html %}
+{% include header18.html %}
+{% include main_nav.html %}
 <div class="u-vskip-3"></div>
 
 {% include talks_menu.html %}

--- a/2018/talks.html
+++ b/2018/talks.html
@@ -4,7 +4,10 @@ layout: default2018
 {% assign img_folder = "assets/img" %}
 {% assign talks = site.data.2018_talks_workshops | where:'type', 'talk' %}
 
-{% include grey_nav.html %}
+{% include earlybird.html %}
+{% include header18.html %}
+{% include main_nav.html %}
+
 <div class="u-vskip-3"></div>
 
 {% include talks_menu.html %}

--- a/2018/workshops.html
+++ b/2018/workshops.html
@@ -4,7 +4,9 @@ layout: default2018
 {% assign img_folder = "./assets/img" %}
 {% assign talks = site.data.2018_talks_workshops | where:'type', 'workshop' %}
 
-{% include grey_nav.html %}
+{% include earlybird.html %}
+{% include header18.html %}
+{% include main_nav.html %}
 <div class="u-vskip-3"></div>
 
 {% include talks_menu.html %}

--- a/_data/2018_talks_workshops.yml
+++ b/_data/2018_talks_workshops.yml
@@ -1,226 +1,208 @@
-- speaker: "Adrian Salceanu"
-  avatar: https://avatars1.githubusercontent.com/u/11292378
-  affiliation: "None"
-  title: "Full Stack Web Development with Genie.jl"
-  type: talk
+- speaker: "Sacha Verweij and Jane Herriman"
+  avatar: https://avatars3.githubusercontent.com/u/5799177?s=460&v=4
+  affiliation: "Stanford University and Julia Computing"
+  title: "An Introduction to Julia"
+  type: workshop
   abstract: >
-    The web is eating the world, but building modern web applications can be an intimidating task. Successful online products must be fast, beautiful and usable. Responsive, maintainable and extendable. Provide simple and flexible web APIs. Be secure. Reach virtually 100% uptime while being easy to debug, extend and update, requiring powerful logging, intelligent caching and rapid scaling strategies.
+    Are you new to Julia?! This beginners’ tutorial should be accessible to anyone with technical computing needs and some experience with another language. We will show you why Julia is special, demonstrate how easy Julia is to learn, and get you writing some Julia code.
+  desc: |
+    Are you new to Julia?! This introductory workshop should be accessible to anyone with technical computing needs and some experience with another programming language. We will show you why Julia is special, demonstrate how easy Julia is to learn, and get you writing Julia code.
 
-    Julia as a language has an enormous potential in the web space thanks to its concise and friendly syntax, the powerful REPL, Unicode support, cross-platform availability, the efficiently compiled code and its parallel and distributed computing capabilities. And Julia's ecosystem already provides low level libraries like HttpServer and WebSockets. But they leave the developers having to spend large amounts of time writing glue and boilerplate code: a tedious, expensive and error prone task.
+    In the first half of this tutorial, we will briefly introduce the language, giving attendees a sense of why Julia is special and what needs Julia meets. After that, we will show how easy it is to pick up Julia’s syntax, covering string manipulation, data structures, loops, conditionals, and functions.
 
-    Genie is a new web framework that leverages Julia's unique combination of features and its extensive collection of packages to empower developers to create high-performance web apps in less time and with less code. It glues low level libraries and contributes its own middlewares to expose a coherent and efficient workflow and a rich API for building web applications.
+    In the second half of this tutorial, we will illustrate Julia’s speed, power, and expressiveness. Among other things, we will look at Julia’s generic linear algebra infrastructure, benchmark Julia against C and Python, and discuss how Julia’s design paradigm leads to flexible performance.
 
-    This talk will give you the guided tour of Genie, introducing the MVC stack and its main components and showing you how to quickly bootstrap a new Genie app and how to easily implement CRUD operations to expose resources over the internet, in an efficient and secure manner. You will see how easy it is to use Genie's API in tandem with Julia's modules system to hook up your code - allowing you to focus on your software's value proposition instead of wasting precious time dealing with the low level details of transporting bytes over the wire.
-  bio: >
-    Web developer since 2000. Architecting and building multi-tier, performance critical web apps handling large amounts of real time data since 2008. PHP, Ruby, JavaScript, F#, Elixir. Now using Julia and Genie to tackle web development's own two-language problem (productive-slow-interpreted vs unproductive-fast-compiled).
+    Exercises to ingrain concepts will be included throughout the tutorial with an integrative exercise at the end.
+  bio: |
+    Jane Herriman is Director of Diversity and Outreach at Julia Computing and a PhD student in the Department of Applied Physics and Materials Science at Caltech. She has completed part of her PhD at Lawrence Livermore National Lab.
 
-    CTO at OLBG. Startup devotee and serial tech founder. IronHack mentor, organizer of Barcelona Julia and Barcelona on Rails. Creator of Genie.jl.
-  resources:
-    - name: "Slides"
-      url: "/2017/assets/slides/Julia_Web_Development_with_Genie--slides.zip"
+    Sacha Verweij has recently completed his PhD in Applied Physics and Computational Mathematics at Stanford University, and is a core developer of the Julia language.
   id: 1
-- speaker: "James Fairbanks & Seth Bromberger"
-  avatar: https://avatars2.githubusercontent.com/u/2753998
-  affiliation: "Georgia Tech Research Institute & Lawrence Livermore National Laboratory"
-  title: "LightGraphs: Our Network, Our Story"
-  type: talk
+
+- speaker: "Andy Ferris"
+  avatar: https://avatars3.githubusercontent.com/u/2974526?s=460&v=4
+  affiliation: "Fugro Roames"
+  title: "A practical introduction to metaprogramming in Julia"
+  type: workshop
   abstract: >
-    Our talk discusses the development and origin of LightGraphs, current features, and future developments. We introduce the package's major design choices in a historical context as a compromise between the three core LightGraphs goals of simplicity, performance, and flexibility. We highlight several areas where specific features of Julia have led to flexible and efficient implementations of graph algorithms.
+    Julia focuses on speed and user productivity, due in part to its metaprogramming capability. This workshop arms you with the knowledge to create fast, generic and easy-to-use APIs using techniques including multiple dispatch, recursion, traits, constant propagation, macros, and generated functions.
+  desc: |
+    In many programming environments, user friendliness must be traded of with execution speed. Using abstractions or “generic” code may come with a run-time overhead. Avoiding abstract or generic code exposes the user to underlying details that they may not care about, making code harder to read and reason about at a higher level, reducing programmer productivity. Often two languages are even employed - one for rapid prototyping, and one for deployment.
 
-    We will highlight our work in centrality measures, graph traversals, and spectral graph algorithms as examples of areas where Julia's performance and design decisions have allowed LightGraphs to provide best-in-class implementations of graph algorithms. We also discuss integration with other organizations – JuliaOpt for matching and flow problems, and the Julia data visualization ecosystem – and highlight specifically LightGraphs' potential to provide leadership on performant graph visualization.
+    It doesn’t have to be this way. The Julia language has been carefully constructed to allow for many common abstractions to be dealt with statically at compile time and have a have a zero run-time cost. This workshop will cover the topic of “metaprogramming” in Julia, which plays a large role in providing for low-cost abstractions and generic APIs. Traditionally, a “meta” program is logic which executes at compile time to help generate the code of a resulting program - that is, it is code that generates other code.
 
-    Finally, we speculate on the influence of Julia's focus on elegant parallel processing to future development of the package.
-  bio: >
-    Dr. James Fairbanks is a Research Engineer at the Georgia Tech Research Institute where he studies problems in complex networks, data analysis, and high performance computing with applications to healthcare and social phenomena.
+    In this workshop we will cover the building blocks of metaprogramming in Julia, starting with one of its core concepts - multiple dispatch, which in combination with the type system is itself is a Turing-complete computational environment. We will then begin working our way to more advanced topics such as traits, macros, constant propagation and generated functions, following approximately this order:
 
-    Seth Bromberger, a Research Scientist at Lawrence Livermore National Laboratory (https://people.llnl.gov/seth), is currently exploring the application of graph theory and machine learning to cybersecurity problems in critical infrastructure.
-  resources:
-    - name: "Slides"
-      url: "/2017/assets/slides/lightgraphsjl.pdf"
+    * Multiple dispatch as a metaprogramming technique
+    * Method inlining: faster than C
+    * Games with tuples: splatting, slurping and recursion
+    * Dispatch revisited: traits
+    * Constant propagation (and what are @pure functions?)
+    * Expressions and macros
+    * Generated functions and when (not) to use them
+    * This workshop will attempt to be a pedagogical tutorial on how and when to use these techniques, full of practical examples I’ve seen in the wild or have used in my own code. Consideration will be given in how to use metaprogramming and still maintain a readable code base. Advice will also be provided on how to work with the compiler, and not against it, and how to make effective use of tools such as @code_typed. At the end of the workshop I hope you will have learned a technique or two that will help you to create generic, user-friendly APIs without sacrificing peak performance.
+  bio: |
+    I am an algorithm and software engineer at Fugro Roames, applying machine learning techniques to big data in order to make sense of and to model the physical world. I have been using Julia since v0.3 for both research and commercial production-at-scale, and am the author of several Julia packages including StaticArrays.
   id: 2
 
-- speaker: "Pearl Li"
-  avatar: https://avatars3.githubusercontent.com/u/6033297?s=460&v=4
-  affiliation: "Federal Reserve Bank of New York"
-  title: "Using Parallel Computing for Macroeconomic Forecasting at the Federal Reserve Bank of New York"
-  type: lightning_talk
-  abstract: >
-    This talk will give an overview of how researchers at the Federal Reserve Bank of New York have implemented economic forecasting and other post-estimation analyses of dynamic stochastic general equilibrium (DSGE) models using Julia’s parallel computing framework. This is part of the most recent release of our DSGE.jl package, following our ports of the DSGE model solution and estimation steps from MATLAB that were presented at JuliaCon in 2016. I will discuss the technical challenges and constraints we faced in our production environment and how we used Julia’s parallel computing tools to substantially reduce both the time and memory usage required to forecast our models. I will present our experiences with the different means of parallel computing offered in Julia - including an extended attempt at using DistributedArrays.jl - and discuss what we have learned about parallelization, both in Julia and in general.
-
-    In addition, I will provide some of our new perspectives on using Julia in a production setting at an academic and policy institution. DSGE models are sometimes called the workhorses of modern macroeconomics, applying insights from microeconomics to inform our understanding of the economy as a whole. They are used to forecast economic variables, investigate counterfactual scenarios, and understand the impact of monetary policy. The New York Fed’s DSGE model is a large-scale model of the U.S. economy, which incorporates the zero lower bound, price/wage stickiness, financial frictions, and other realistic features of the economy. Solving, estimating, and forecasting it presents a series of high-dimensional problems which are well suited for implementation in Julia.
-
-
-    Disclaimer: This talk reflects the experience of the author and does not represent an endorsement by the Federal Reserve Bank of New York or the Federal Reserve System of any particular product or service. The views expressed in this talk are those of the authors and do not necessarily reflect the position of the Federal Reserve Bank of New York or the Federal Reserve System. Any errors or omissions are the responsibility of the authors.
-  bio: >
-    I'm a Research Analyst at the New York Fed using Julia to estimate and forecast macroeconomic models. I'm interested in applying the frontier of scientific computing to economic research, so that we can solve more realistic and complex models.
-  resources:
-    - name: "Slides"
-      url: "https://github.com/pearlzli/dsge-forecasting_juliacon-2017"
-  id: 3
-
-- speaker: "David P. Sanders"
-  affiliation: "Department of Physics, Faculty of Sciences, National University of Mexico"
-  title: "Equations, inequalities and global optimisation: guaranteed solutions using interval methods and constraint propagation"
-  type: lightning_talk
-  abstract: >
-    How can we find all solutions of a system of nonlinear equations, the "feasible set" satisfied by a collection of 
-    inequalities, or the global optimum of a complicated function? These are all known to be hard problems in numerical analysis.
-    
-    In this talk, we will show how to solve all of these problems, in a guaranteed way, using a collection of related methods
-    based on interval arithmetic, provided by the `IntervalArithmetic.jl` package. The starting point is a simple
-    dimension-independent bisection code, which can be enhanced in a variety of ways. This method is rigorous: it is 
-    guaranteed to find all roots, or to find the global minimum, respectively.
-    
-    One key idea is the use of continuous constraint propagation, which allows us to remove large portions of the search space 
-    that are infeasible. We will explain the basics of this method, in particular the 
-    "forward-backward contractor", and describe the implementation in the `IntervalConstraintProgramming.jl` package.
-
-    This package generates forward and backward code automatically from a Julia expression, using metaprogramming techniques. 
-    These are combined into "contractors", i.e. operators that contract a box without removing any portion of the set of 
-    interest. These, in turn, give 
-    a rigorous answer to the question whether a given box lies inside the feasible set or not. In this way, a paving 
-    (collection of boxes) is built up that approximates the set.
-
-  bio: >
-    David P. Sanders is associate professor of computational physics in the Department of Physics of the Faculty of Sciences at the National University of Mexico in Mexico City.
-
-    His video tutorials on Julia have a total of 75,000 views on YouTube.
-    He is a principal author of the [`ValidatedNumerics.jl`](https://github.com/dpsanders/ValidatedNumerics.jl) package for interval arithmetic, and [`IntervalConstraintProgramming.jl`](https://github.com/dpsanders/IntervalConstraintProgramming.jl) for constraint propagation.
-  resources:
-    - name: "Slides"
-      url: "https://github.com/dpsanders/juliacon_2017_calculating_with_sets"
-  id: 4
-
-- speaker: "Kristoffer Carlsson"
-  affiliation: "Chalmers University of Technology"
-  title: "OhMyREPL.jl: This Is My REPL; There Are Many Like It, But This One Is Mine"
-  type: talk
-  abstract: >
-    By default, Julia comes with a powerful REPL that itself is completely written in Julia.
-    It has, among other things, tab completion, customizable keybindings and different prompt modes to use the shell or access the help system.
-    However, with regards to visual customization there are not that many options for a user to tweak.
-    To that end, I created the package OhMyREPL.jl.
-    Upon loading, it hooks into the REPL and adds features such as syntax highlighting, matching bracket highlighting, functionality to modify input and output prompts and a new way of printing stacktraces and error messages.
-    It also contains some non-visual features, like allowing text that has been copied from a REPL session to be directly pasted back into a REPL and quickly opening the location of stack frames from a stacktrace in an editor.
-    The talk will give an overview of the different features, discuss which features managed to get upstreamed to Julia v0.6 and, if time allows, outline the internals of the package.
-  bio: >
-    Ph.D. student in computational mechanics at Chalmers University of Technology. Using Julia both for studies and as a hobby.
-  resources:
-    - name: "Slides"
-      url: "https://github.com/KristofferC/OhMyREPL_JuliaCon2017"
-  id: 5
-
-- speaker: "Deniz Yuret"
-  affiliation: "Koç University, Istanbul"
-  title: "Knet.jl: Beginning Deep Learning with 100 Lines of Julia"
+- speaker: "Pontus Stenetorp"
+  avatar: https://avatars1.githubusercontent.com/u/354934?s=460&v=4
+  affiliation: "University College London"
+  title: "Machine Learning with Julia: Elegance, Speed and Ease"
   type: workshop
   abstract: >
-    Knet (pronounced "kay-net") is the Koç University deep learning framework implemented in Julia by Deniz Yuret and collaborators. Knet uses dynamic computational graphs generated at runtime for automatic differentiation of (almost) any Julia code. This allows machine learning models to be implemented by only describing the forward calculation (i.e. the computation from parameters and data to loss) using the full power and expressivity of Julia. The implementation can use helper functions, loops, conditionals, recursion, closures, tuples and dictionaries, array indexing, concatenation and other high level language features, some of which are often missing in the restricted modeling languages of static computational graph systems like Theano, Torch, Caffe and Tensorflow. GPU operation is supported by simply using the KnetArray type instead of regular Array for parameters and data. High performance is achieved using custom memory management and efficient GPU kernels.
-  bio: >
-    Deniz Yuret received his BS, MS, and Ph.D. at MIT working at the AI Lab on machine learning and natural language processing during 1988-1999. He co-founded Inquira, Inc., a startup commercializing question answering technology which was later acquired by Oracle.  He is currently an associate professor of Computer Engineering at Koç University, Istanbul and founder of its Artificial Intelligence Laboratory. In his spare time he develops Knet.jl, a Julia deep learning framework that uses dynamic computational graphs generated at runtime for automatic differentiation of (almost) any Julia code.
+    Machine Learning has become one of the hottest research and industry areas over the last few years; we believe Julia is the strongest contender to become the language for Machine Learning and in this tutorial we will give a flying start to train/deploy models and use of the power that Julia brings.
+  desc: |
+    Machine Learning (ML) is at its core the art of programming by data, rather than by hand, and ML has risen to become one of the most desirable skills in academia and industry. The common maxim is that two traits control who rules the ML landscape, ability to find and ingest more data and those that can innovate the quickest. Given these traits, we argue that Julia is uniquely poised as a very strong contender as the language for ML; as we allow for quick development cycles and offer unrivalled speed. After a quick introduction to the basics of ML, we will give the audience a description of the lay of the land in terms of libraries and frameworks in Julia, and finally proceed to build simple to complex models using the premier framework Flux. After attending the workshop the audience will be familiar with the basics of ML to avoid common pitfalls and be ready to tackle their own ML problems the Julian way.
+  bio: |
+    I am Pontus Stenetorp, a researcher and educator that finds Natural Language Processing (NLP) and Machine Learning research to be fascinating. The widely-adopted text annotation and visualisation tool brat is one of my creations and since 2012 a majority of my work has been on representation learning (Deep Learning) for natural language.
+
+    My current research focuses on end-to-end models that learns with a minimal amount of human supervision – with a particular focus on allowing computers to pass real-world exams – and is supported by the Paul G Allen Family Foundation. If you share any of my research interests, do have a look at my list of publications and if you have questions regarding my research, feel free to contact me. I also teach and supervise student research projects in my area of expertise.
+
+    Currently, I am a Senior Research Associate at University College London (UCL) and a member of the Machine Reading Group lead by Reader Sebastian Riedel at the Department of Computer Science. I received a PhD from the University of Tokyo in 2013 and a MSc Eng from the Royal Institute of Technology (KTH) in 2010. In my spare time I contribute to the Julia programming language community, read plenty of books, and enjoy being a mediocre amateur photographer.
   resources:
     - name: "Repo"
-      url: "https://github.com/denizyuret/Knet.jl"
+      url: "http://fluxml.ai/"
+  id: 3
+
+- speaker: "Sheehan Olver"
+  avatar: https://avatars3.githubusercontent.com/u/1229737?s=400&v=4
+  affiliation: "Imperial College, London"
+  title: "Numerical Analysis in Julia"
+  type: workshop
+  abstract: >
+    This workshop brings together 5 speakers on different topics in numerical analysis, to demonstrate the strengths of Julia’s approach to scientific computing in atomistic simulations, function approximation, differential equations, fast transformations, validated numerics, and linear algebra.
+  desc: |
+    This workshop proposal brings together 5 speakers on different topics in numerical analysis. The aim of the workshop is to have demonstrations of Julia packages in this area in a way to motivate the results to a “general” audience. Our speakers cover a variety of areas to give a broad demonstration of what is now possible using Julia.
+
+    Speakers and titles
+    -------------------
+    * Sheehan Olver: ApproxFun.jl, Approximating Functions and Solving Differential Equations.
+    * Christoph Ortner: JuLIP.jl, Julia for Atomistic Simulation.
+    * David P. Sanders: ValidatedNumerics.jl, Rigorous Floating-point Calculations with Interval Arithmetic.
+    * R. Mikael Slevinsky: FastTransforms.jl, Fast Orthogonal Polynomial Transforms.
+    * Weijian Zhang: MatrixDepot.jl, Testing Linear Algebra Algorithms in Julia.
+
+    Abstracts
+    ---------
+    *ApproxFun.jl, Approximating Functions and Solving Differential Equations*  
+    Sheehan Olver, Imperial College, London
+
+    ApproxFun.jl is a Julia package that makes working with functions on a computer fast and easy. Basic algebra and calculus operations are available, so that one can, for example, differentiate the function $\sin\cos^2 x$ as easy as typing `sin(cos(x)^2)'`. Further capabilities include solving differential equations and random number sampling. This talk will demonstrate the capabilities of ApproxFun, and how Julia’s approach to typing allows for these capabilities to be used with other types, such as Dual numbers (from DualNumbers.jl) or BigFloats.
+
+    *JuLIP.jl, Julia for Atomistic Simulation*  
+    Christoph Ortner, University of Warwick
+
+    I will introduce a family of Julia packages for atomistic simulation primarily of material systems. This includes tools for developing new interatomic potentials or electronic structure models, generating atomistic configurations, imposing boundary conditions and constraints, and performing molecular dynamics simulations, minimisation and saddle search. All of these aspects of molecular simulations involve interesting questions for numerical analysis and applied mathematics in general. The purpose of the JuLIP eco-system is (1) to make it easy for mathematicians to work with physically realistic models; (2) to link to established atomistic simulation software so that new models algorithms can feed directly back into material modelling.
+
+    *ValidatedNumerics.jl, Rigorous Floating-point Calculations with Interval Arithmetic*  
+    David P. Sanders, Universidad Nacional Autónoma de México
+
+    I will present a suite of Julia packages in the JuliaIntervals organisation which provide implementations of numerical methods that provide results that are guaranteed to be correct. These are based on interval arithmetic, i.e. defining arithmetic and elementary functions acting on intervals of real numbers.
+
+    This gives us a tool to calculate with continuous sets of real numbers, and thus rigorously bound the range of a function over a given set. Applications of this technology include finding, in a guaranteed way, all the roots of a multivariable function in a given region of space, and finding the global optimum of a function.
+
+    *FastTransforms.jl, Fast Orthogonal Polynomial Transforms*  
+    R. Mikael Slevinsky, University of Manitoba
+
+    FastTransforms.jl allows the user to conveniently work with orthogonal polynomials with degrees well into the millions. Transforms include conversion between Jacobi polynomial expansions, with Chebyshev, Legendre, and ultraspherical polynomial transforms as special cases. For the signal processor, all three types of nonuniform fast Fourier transforms available. As well, spherical harmonic transforms and transforms between orthogonal polynomials on the triangle allow for the efficient simulation of partial differential equations of evolution. Algorithms include methods based on asymptotic formulae to relate the transforms to a small number of fast Fourier transforms, matrix factorizations based on the Hadamard product, hierarchical matrix decompositions à la Fast Multipole Method, and the butterfly algorithm.
+
+    *MatrixDepot.jl, Testing Linear Algebra Algorithms in Julia*  
+    Weijian Zhang, University of Manchester
+
+    Test matrices are important for exploring the behavior of linear algebra algorithms and for measuring their performance with respect to accuracy, stability, convergence rate, speed, or robustness. We give a brief historical remark on the development of test matrices in different programming languages and then focus on the advantage of using MatrixDepot.jl for testing and exploring new algorithms in Julia. Using both contrived and real-world examples, we demonstrate the power of MatrixDepot.jl which takes advantage of many nice Julia features, such as using multiple dispatch to help provide a simple user interface and to allow matrices to be generated in any of the numeric data types supported by the language.
+  bio: |
+    I am a Reader (equivalent to Assoc. Professor) in Applied Mathematics and Mathematical Physics at Imperial College, London. My research is in numerics, in particular spectral methods and complex analytical methods. I have extensive experience with programming Julia, having developed several packages (ApproxFun.jl, BandedMatrices.jl, BlockBandedMatrices.jl, etc.).
+  id: 4
+
+- speaker: "David Anthoff"
+  avatar: https://avatars2.githubusercontent.com/u/1036561?s=400&v=4
+  affiliation: "University of California, Berkeley"
+  title: "Queryverse"
+  type: workshop
+  abstract: >
+    This workshop will introduce the Queryverse family of packages, a unified data science stack on julia. It provides tools for file IO, data querying, visual data exploration and statistical plotting. It also integrates with a large number of other julia packages.
+  desc: |
+    This talk will give an update on the current state of the Queryverse. I will highlight packages for file IO (CSVFiles.jl, ExcelFiles.jl, StatFiles.jl, FeatherFiles.jl, ParquetFiles.jl), querying and manipulating data (Query.jl), visual data exploration (DataVoyager.jl) and graphics (VegaLite.jl). I will show how all of these pieces are designed to work together and provide a unified API for users that spans traditional tabular data and data in custom julia types. I will also highlight how the Queryverse integrates smoothly with all the other julia packages in this space.
+  bio: |
+    David Anthoff is an environmental economist who studies climate change and environmental policy. He co-develops the integrated assessment model FUND that is used widely in academic research and in policy analysis. His research has appeared in Science, the American Economic Review, Nature Climate Change, the Journal of Environmental Economics and Management, Environmental and Resource Economics, the Oxford Review of Economic Policy and other academic journals. He contributed a background research paper to the Stern Review and has advised numerous organizations (including US EPA and the Canadian National Round Table on the Environment and the Economy) on the economics of climate change.
+
+    He is an assistant professor in the Energy and Resources Group at the University of California at Berkeley, a senior fellow at the Berkeley Institute for Data Science and a University Fellow at Resources for the Future. Previously he was an assistant professor in the School of Natural Resources and Environment at the University of Michigan, a postdoc at the University of California, Berkeley and a postdoc at the Economic and Social Research Institute in Ireland. He also was a visiting research fellow at the Smith School of Enterprise and the Environment, University of Oxford.
+
+    He holds a PhD (Dr. rer. pol.) in economics from the University of Hamburg (Germany) and the International Max Planck Research School on Earth System Modelling, a MSc in Environmental Change and Management from the University of Oxford (UK) and a M.Phil. in philosophy, logic and theory of science from Ludwig-Maximilians-Universität München (Germany).
+  resources:
+    - name: "Repo"
+      url: "https://github.com/davidanthoff/Query.jl"
+  id: 5
+
+- speaker: "Chris Rackauckas"
+  avatar: https://avatars3.githubusercontent.com/u/1814174?s=460&v=4
+  affiliation: "UC Irvine and MIT"
+  title: "Solving Partial Differential Equations with Julia "
+  type: workshop
+  abstract: >
+    Climate scientists solve fluid dynamics PDEs. Biologists solve reaction-diffusion PDEs. Economists solve optimal control PDEs. But solving PDEs is hard! Where do you start? This workshop gives a broad overview of the Julia package ecosystem and shows how to tie it together to solve these problems.
+  desc: |
+    Partial differential equations (PDEs) are used throughout scientific disciplines, modeling diverse phenomena such as the spread of chemical concentrations across biological organisms to global temperature flows. However, solving PDEs efficiently is not easy: it requires a vertical toolkit with many interconnected pieces. In this workshop we will introduce the participants to some basic PDEs, where they come from, and how to tie together the various tools across the Julia package ecosystem to solve them efficiently.
+
+    We will start by focusing on elliptic problems and show how these decompose into solving sparse linear systems. To solve the resulting linear systems, the participants will be introduced three methods: Julia’s special matrix types for efficient dense solutions, BandedMatrices.jl for more generic banded operators, and IterativeSolvers.jl for Krylov methods. The differences between the methodologies and the current status of distributed and GPU compatibility will be discussed. From there, the extension to nonlinear elliptic problems will be shown as effectively solving nonlinear systems with sparse Jacobians, and demonstrations/comparisons of Roots.jl, NLsolve.jl, and Sundials.jl’s KINSOL for solving the resulting systems will be addressed. Lastly, the concept of pseudospectral discretizations will be introduced using the library ApproxFun.jl, it will be shown how this methodology simply leads to different linear/nonlinear systems.
+
+    After understanding the tooling for elliptic PDEs, “time-dependent” PDEs such as parabolic and hyperbolic PDEs will be introduced. It will be shown how similar discretizations as done in the elliptic portion lead to systems of coupled ordinary differential equations (ODEs). It will be demonstrated how to efficiently solve the resulting ODE systems via DifferentialEquations.jl using methods such as via banded Jacobian Rosenbrock integrators, Newton-Krylov BDF, Implicit-Explicit (IMEX) Runge-Kutta, and exponential integrators like ETDRK4. Participants will be shown how to integrate pseudospectral operators from ApproxFun.jl and linear solvers from IterativeSolvers.jl to customize the integrators to their problem. Additionally, special time-stepping issues for hyperbolic PDEs and the strong-stability preserving (SSP) integrators will be introduced.
+
+    Together, the workshop participants should be able to leave with a good understanding of how to tie together the Julia scientific packages to efficiently solve a large class of partial differential equations.
+  bio: |
+    I am a mathematician and theoretical biologist at the University of California, Irvine. My programming language of choice is Julia and I am the lead developer of the JuliaDiffEq organization dedicated to solving differential equations (and includes the package DifferentialEquations.jl). My research is in time stepping methods for solving stochastic differential equations (SDEs) and applications to stochastic partial differential equations (SPDEs) which model biological development.
+  resources:
+    - name: "Repo"
+      url: "https://github.com/JuliaDiffEq/DifferentialEquations.jl"
   id: 6
 
-- speaker: "Spencer Lyon"
-  affiliation: "NYU Stern"
-  title: "The Dolo Modeling Framework"
-  type: talk
+- speaker: "Juan Pablo Vielma"
+  avatar: https://avatars2.githubusercontent.com/u/6369022?s=460&v=4
+  affiliation: "MIT Sloan"
+  title: "The JuMP ecosystem for mathematical optimization "
+  type: workshop
   abstract: >
-    We present a family of three Julia packages that together constitute a complete framework to describe and solve rational expectation models in economics. Dolang.jl is an equation parser and compiler that understands how to compile latex-like strings describing systems of equations into efficient Julia functions for evaluating the levels or derivatives of the equations. Dolo.jl leverages Dolang and implements a variety of frontier algorithms for solving a wide class of discrete time, continuous control rational expectations models. Finally, Dyno.jl builds upon Dolang to implement a Julia prototype of the Matlab-based dynare software library used extensively throughout academia and the public sector to approximate the solution to and estimate rational expectations models.
-  bio: >
-    Economics Ph.D. student at NYU Stern. Active Julia member since 0.2
+    JuMP is an award-winning DSL for mathematical optimization that has quickly become the gold-standard for its simplicity, performance, and versatility. A major overhaul of JuMP will be finalized during the JuMP-dev workshop in June, so it is the perfect time for an updated tutorial and feature demo.
+  desc: |
+    JuMP is a multi-award-winning domain-specific language for mathematical optimization. JuMP has already been successfully used in academic and industrial problems related to marketing, causal inference, daily fantasy sports, optimal control of aerial drones, machine learning, school bus routing, sustainable power systems expansion, and decarbonization of electrical networks. The JuMP ecosystem gives access to a wide range of highly-effective commercial and open-source optimization tools in a natural syntax that requires only a basic knowledge of mathematical optimization. JuMP provides this access with a performance that matches or exceeds those of commercial and open-source alternatives, as well as unparalleled versatility and extensibility allowed by the advanced features of the Julia language. In particular, JuMP and its infrastructure was used to develop the solver Pajarito.jl, which is currently the state-of-the-art for the class known as mixed-integer conic optimization problems. JuMP has recently received a major overhaul that should further facilitate the development of similar advanced optimization tools.
+
+    In this tutorial, we begin with basic syntax and features of JuMP and associated packages assuming no previous knowledge of JuMP and only an elementary knowledge of mathematical optimization. We then cover more advanced features, give performance tips, and cover the recent improvements to JuMP developed in the second Annual JuMP-dev Workshop. Finally, we demo some state-of-the-art features, including showing how various packages in the rich Julia ecosystem can be seamlessly combined to provide simple solutions to complicated problems in the optimal control of aerial drones.
+  bio: |
+    Juan Pablo Vielma is an associate professor at MIT’s Sloan School of Management and is also associated to MIT’s Operations Research Center. Juan Pablo’s research interests include the development of theory and technology for mathematical optimization and their application to problems in marketing, statistics and sustainable management of energy and natural resources. Juan Pablo is the Ph.D. advisor of two of the creators of JuMP and continues to be closely involved in JuMP’s development. Some projects he is currently associated with are the Pajarito Solver, JuMP’s extension for piecewise linear optimization and the Cassette and Capstan tools.
+  resources:
+    - name: "Repo"
+      url: "https://github.com/JuliaOpt/JuMP.jl"
   id: 7
 
-- speaker: "Bart Janssens"
-  affiliation: "Royal Military Academy"
-  title: "QML.jl: Cross-platform GUIs for Julia"
+- speaker: "Avik Sengupta"
+  avatar: https://avatars1.githubusercontent.com/u/378918?s=460&v=4
+  affiliation: "Julia Computing"
+  title: "Natural Language Processing in Julia"
   type: workshop
   abstract: >
-    The QML.jl (https://github.com/barche/QML.jl) package enables using the QML markup language from the Qt library to build graphical user interfaces for Julia programs. The package follows the recommended Qt practices and promotes separation between the GUI code and application logic. After a short introduction of these principles, the first topic of this talk will be the basic communication between QML and Julia, which happens through Julia functions and data (including composite types) stored in context properties. Using just a few basic building blocks, this makes all of the QML widgets available for interaction with Julia. The next part of the talk deals with Julia-specific extensions, such as the Julia ListModel, interfacing with the display system and GLVisualize and GR.jl support. These features will be illustrated using live demos, based on the examples in the QML.jl repository. Finally, some ideas for extending and improving the package will be listed, soliciting many contributions hopefully.
+    A hands on workshop demonstrating the use of natural language processing tools in Julia. Working with textual data, we will discuss methods for data collection, parsing, pre-processing, embedding, classification and deep neural networks.
+  desc: |
+    In this hands on workshop, we will explore the use of natural language processing tools in Julia, with a particular focus on statistical machine learning based approaches. The content will be based primarily around the TextAnalysis.jl and Flux.jl packages. We will learn some of the primary algorithms in this area, and implement practical examples using these packages. The course will be aimed at someone who has a basic understanding of the Julia programming language, but no prior experience of natural language processing
 
-    The target audience for this talk is anyone interested in developing GUIs for their Julia application with a consistent look on OS X, Linux and Windows. All user-facing code is pure Julia and QML, no C++ knowledge is required to use the package.
-  bio: >
-    I am an associate professor at the mechanics department of the Royal Military Academy. For my Ph.D., I worked on Coolfluid, a C++ framework for computational fluid dynamics with a domain specific language. My interest in Julia is sparked by its powerful metaprogramming functionality coupled with C++-like performance, together with much better accessibility for students. To ease the transition to Julia, we are working on making some C++ libraries available in Julia. The QML.jl package is part of this effort. We also use Julia in our daily teaching activities, to provide students with interactive solutions to exercises.
+    * Data Collection
+        * Using existing corpora
+        * Web scraping to collect your own data
+        * Data storage and representation
+    * Pre-processing
+        * Stemming
+        * Stopwords
+    * Word representations
+        * Bag of words, TF-IDF
+        * Text Rank algorithm for summarisation
+    * Word Embeddings
+    * Deep neural networks for machine learning
+        * Language Detection
+        * Parsing
+        * Text generation
+  bio: |
+    Avik has spent many years helping investment banks leverage technology in risk and capital markets. He’s worked on bringing AI powered solutions to investment research, and is currently the VP of Engineering at Julia Computing.
   resources:
-    - name: "Slides"
-      url: "https://github.com/barche/qml-juliacon2017"
+    - name: "Repo"
+      url: "https://github.com/JuliaText/TextAnalysis.jl"
   id: 8
-
-- speaker: "Jorge Perez and Luis Benet"
-  affiliation: "UNAM (Mexico)"
-  title: "TaylorIntegration.jl: Taylor's Integration Method in Julia"
-  type: lightning_talk
-  abstract: >
-    In this talk we shall present TaylorIntegration.jl, an ODE integration package using Taylor's method in Julia. The main idea of Taylor's method is to approximate locally the solution by means by a *high-order* Taylor expansion, whose coefficients are computed recursively using automatic differentiation techniques. One of the principal advantages of Taylor's method is that, whenever high accuracy is required, the order of the method can be increased, which is more efficient computationally than taking smaller time steps.
-    The accuracy of Taylor's method permits to have round-off errors per integration step. Traditionally, it has been difficult to
-    make a generic Taylor integration package, but Julia permits this beautifully. We shall present some examples of the application of this method to ODE integration, including the whole computation of the Lyapunov spectrum, use of jet transport techniques, and parameter sensitivity. Open issues related to improving performance will be described.
-  bio: >
-    Jorge Perez is a Physics Ph.D. student at UNAM, Mexico, under supervision of Luis Benet and David P. Sanders, authors of TaylorSeries.jl and ValidatedNumerics.jl. His Ph.D. research project is related to understanding the dynamics of minor Solar System objects: comets, asteroids, etc. He is coauthor of TaylorIntegration.jl and a contributor to TaylorSeries.jl.
-
-    Luis Benet is Associate Professor at the Instituto de Ciencias Físicas of the National University of Mexico (UNAM). He is mainly interested in classical and quantum chaos, including the dynamics of Solar System objects. He is
-    coauthor of ValidatedNumerics.jl, TaylorSeries.jl and TaylorIntegration.jl, and has contributed to other Julia packages.
-  resources:
-    - name: "Slides"
-      url: "http://nbviewer.jupyter.org/format/slides/github/PerezHz/TaylorIntegration.jl/blob/master/examples/JuliaCon2017/TaylorIntegration_JuliaCon.ipynb"
-  id: 9
-
-- speaker: "Camila Metello & Joaquim Garcia"
-  affiliation: "PSR Inc."
-  title: "Stochastic Optimization Models on Power Systems"
-  type: talk
-  abstract: >
-    We will present 3 tools for decision making under uncertainty in the power systems area: SDDP, a tool for optimal hourly operation of complex power systems; OptGen, a computational tool for determining the least-cost expansion of a multi-regional hydrothermal system; OptFlow, a mathematical model to optimize operation of a generation/transmission system with AC electrical network constraints.
-
-    These models have been used by system operators, regulators and investors in more than seventy countries in the Americas, Asia-Pacific, Europe and Africa, including some of the largest hydro based systems in the world, such as the Nordic pool, Canada, the US Pacific Northwest and Brazil. SDDP is also the model used by the World Bank staff in their planning studies of countries in Asia, Africa and Latin America.  OptGen had some interesting applications regional studies such as the interconnection of Central America, the Balkan regions, the interconnection of nine South American countries, Africa (Egypt-Sudan-Ethiopia and Morocco-Spain) and Central Asia.
-    The original version of all 3 models was written in FORTRAN with the aid of some modelling tool or higher level API: AMPL for OptFlow, Mosel for OptGen and COIN-OR API for SDDP. Similar to any software, maintaining the code and adding new features became increasingly complex because they have to be built upon older data structures and program architectures.
-
-    These concerns motivated PSR to develop an updated version of these programs written entirely in julia (with JuMP and MathProgBase) for three basic reasons: (i) the code is concise and very readable; (ii) the availability of an advanced optimization “ecosystem”; and (iii) excellent resources for distributed processing (CPUs and GPUs). We retained the use of Xpress by developing the Xpress.jl library. We also use MPI.jl for distributed processing (including multiple servers in AWS).
-
-    The computational performance of the new code is matches the current ones’, which is very encouraging given that the current FORTRAN code has been optimized for several years based on thousands of studies. Also, the julia code incorporates several new modeling features that were easy to implement in all the 3 models: including SDP and SOCP relaxations for OPF and SDDiP method for stochastic integer optimization, confirming our expectation of faster model development.
-
-    The new models were incorporated to an integrated planning system for Peru being developed by PSR, which will be delivered in August 2017. They are also being internally tested as a “shadow” to the current version for studies in several countries and was delivered for beta testing for some PSR clients. The official release is scheduled for the end of 2017.
-  bio: >
-    Camila graduated as an industrial engineer and has a MSc in Decision Analysis from PUC-Rio. Attended UC Berkeley for a semester during under graduation. Joined PSR in 2013, where, at present, works with the development of the models of optimization of hydrothermal dispatch under uncertainty with network constraints (SDDP model) and electric systems expansion planning (OPTGEN model).
-
-
-    Joaquim has a BSc degree in electrical engineering and a BSc degree in mathematics, both from PUC -Rio and is currently working towards a PhD in electrical engineering with emphasis on decision support, also at PUC-Rio. During his undergraduate studies, he attended a year at UC Santa Barbara. He joined PSR in 2015 has been been working on the development of optimization models for hydro-thermal dispatch under uncertainty with transmission constraints  reliability analysis, electrical systems expansion planning and nonlinear optimal power flow. Before PSR Joaquim worked with decision support at LAMPS (Laboratory of applied mathematical programming and statistics, at PUC-Rio) and with OTDR and Signal Processing at LabOpt (Optoelectronics laboratory, at PUC-Rio).
-  id: 10
-
-- speaker: "Héctor Andrade Loarca"
-  affiliation: "Technical University of Berlin (TUB)"
-  title: "Fast Multidimensional Signal Processing with Shearlab.jl"
-  type: lightning_talk
-  abstract: >
-    The Shearlet Transform was proposed in 2005 by the Professor Gitta Kutyniok (http://www3.math.tu-berlin.de/numerik/mt/mt/www.shearlet.org/papers/SMRuADaSO.pdf) and her colleagues as a multidimensional generalization of the Wavelet Transform, and since then it has been adopted by a lot of Companies and Institutes by its stable and optimal representation of multidimensional signals. Shearlab.jl is a already registered Julia package (https://github.com/arsenal9971/Shearlab.jl) based in the most used implementation of Shearlet Transform programmed in Matlab by the Research Group of Prof. Kutyniok (http://www.shearlab.org/software); improving it by at least double the speed on different experiments.
-
-    As examples of applications of Shearlet Transform one has Image Denoising, Image Inpaiting and Video Compression; for instance I used it mainly to reconstruct the Light Field of a 3D Scene from Sparse Photographic Samples of Different Perspectives with Stereo Vision purposes. A lot of research institutes and companies have already adopted the Shearlet Transform in their work (e.g. Fraunhofer Institute in Berlin and Charité Hospital in Berlin, Mathematical Institute of TU Berlin) by its directional sensitivity, reconstruction stability and sparse representation.
-  bio: >
-    Ph.D. student in Mathematics at the Technical University of Berlin (TUB) with Professor Gitta Kutyniok  as advisor;  major in Mathematics and Physics from National University of México (UNAM); ex Data Scientist of a mexican Open Governance Start Up (OPI); with experience in Data Mining, Machine Learning, Computational Harmonic Analysis and Computer Vision. Currently developing Light Field Reconstruction algorithms using Digital Signal Processing tools for 3D Imaging and Stereo Vision. Is known by his colleagues for using Julia on everything. It was introduced to Julia by Professor David Philip Sanders and after both gave a course on Computational Statistical Physics using Julia at the National University of México  (UNAM) which convinced him to adopt Julia as his main programming language.
-  id: 11
-
-- speaker: "Ajay Mendez"
-  affiliation: "Founder, Kinant.com"
-  title: "Julia for Infrastructure: Experiences in Developing a Distributed Storage Service"
-  type: lightning_talk
-  abstract: >
-    Julia is a language designed for numerical computing and it does that job pretty well. However, the emphasis on numerical computing and data science tends to overshadow the language’s other use cases. In this talk we share our experiences using Julia to build a distributed data fabric using commodity hardware. A data fabric is a distributed storage system that abstracts away the physical infrastructure and makes data available to applications using well known protocols such as NFS or S3. Our talk focuses on how we use Julia to implement a data fabric with specific examples. We will discuss some of the shortcomings and how we circumvented them. Finally we close by a cost benefit analysis of developing in Julia and how it can be a critical advantage in bringing products to market.
-  bio: >
-    Ajay works on systems and infrastructure software for fun and profit. He has dabbled in operating systems, memory allocators, file systems and distributed systems. He founded kinant.com in 2017 to simplify the deployment and usage of storage infrastructure.
-  resources:
-    - name: "Slides"
-      url: "/2017/assets/slides/Julia for Infrastructure (Juliacon '17).pdf"
-  id: 12
-
-- speaker: "Simon Byrne, Ranjan Anantharaman"
-  affiliation: "Julia Computing, Inc."
-  title: "Miletus: A Financial Modelling Suite in Julia"
-  type: workshop
-  abstract: >
-    Miletus is a financial software suite in Julia, with a financial contract specification language and extensive modelling features. In this talk, we’ll discuss the design principles involved in how to model a contract from primitive components, and how Julia’s language features lend themselves intuitively to this task. We’ll then talk about the various features of the software suite such as closed form models, binomial trees and computation of price sensitivities (aka “the Greeks”), providing several examples and code snippets, along with comparisons with other popular frameworks in this space.
-
-  bio: >
-    Dr Simon Byrne is a quantitative software developer at Julia Computing, where he implements cutting edge numerical routines for statistical and financial models. Simon has a Ph.D. in statistics from the University of Cambridge, and has extensive experience in computational statistics and machine learning in both academia and industry. He has been contributing to the Julia project since 2012. Ranjan Anantharaman is a data scientist at Julia Computing where he works on numerical software in a variety of domains. His interests include scientific computing and machine learning. He has been contributing to the Julia project and ecosystem since 2015.
-  id: 13
-

--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -19,7 +19,7 @@
           </li -->
           <li class="nav-item">
             <!-- <a class="nav-link" href="/{{current_folder}}/all_talks.html">talks & workshops</a> -->
-            <a class="nav-link" href="javascript:alert('coming soon');">talks & workshops</a>
+            <a class="nav-link" href="/{{current_folder}}/workshops.html">talks & workshops</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/{{current_folder}}/schedule">schedule</a>

--- a/_includes/talks_menu.html
+++ b/_includes/talks_menu.html
@@ -2,8 +2,8 @@
   <div class="text-center">
     <div class="btn-group btn-group-centered" role="group" aria-label="Talks categories" id="talks-filter">
         <a href="/2018/all_talks.html" class="btn btn-default {% if page.url == '/2018/all_talks.html' %}active{% endif %}" role="button">all</a>
-        <a href="/2018/talks.html" class="btn btn-default {% if page.url == '/2018/talks.html' %}active{% endif %}" role="button">talks</a>
-        <a href="/2018/lightning_talks.html" class="btn btn-default {% if page.url == '/2018/lightning_talks.html' %}active{% endif %}" role="button">lightning talks</a>
+        <!-- <a href="/2018/talks.html" class="btn btn-default {% if page.url == '/2018/talks.html' %}active{% endif %}" role="button">talks</a> -->
+        <!-- <a href="/2018/lightning_talks.html" class="btn btn-default {% if page.url == '/2018/lightning_talks.html' %}active{% endif %}" role="button">lightning talks</a> -->
         <a href="/2018/workshops.html" class="btn btn-default {% if page.url == '/2018/workshops.html' %}active{% endif %}" role="button">workshops</a>
     </div>
   </div>

--- a/_layouts/2018speaker.html
+++ b/_layouts/2018speaker.html
@@ -2,7 +2,9 @@
 layout: default2018
 ---
 
-{% include grey_nav.html %}
+{% include earlybird.html %}
+{% include header18.html %}
+{% include main_nav.html %}
 
 <link rel="stylesheet" href="/{{current_folder}}/assets/css/font-awesome/css/font-awesome.min.css">
 <link rel="stylesheet" href="/{{current_folder}}/assets/css/jssocials.css">
@@ -42,10 +44,10 @@ layout: default2018
   <div class="content-box-talk">
     <h2>{{page.title}}</h2>
 
-    <p>{{page.abstract}}</p>
+    <p>{{ page.desc | markdownify }}</p>
 
     <h3>Speaker's bio</h3>
-    <p>{{ page.bio }}</p>
+    <p>{{ page.bio | markdownify }}</p>
 
     {% if page.resources %}
     <h3>Resources</h3>


### PR DESCRIPTION
cc: @essenciary 

Currently only workshops are populated, so the nav link goes to `workshops.html`. Should change to `talks.html` eventually. 

We've asked speakers to enter separate abstracts and talk descriptions, so I've added support for that. 

`talks/index.html` seems to be redundant, should probably be deleted? 