### PR TITLE
Add myself to committee website

### DIFF
--- a/2022/committee.md
+++ b/2022/committee.md
@@ -11,6 +11,7 @@
 * Logan Kilpatrick, Media and Publicity [Twitter](https://twitter.com/OfficialLoganK)
 * Carsten Bauer, Proceedings Chair
 * Tom Kwong, Infrastructure [Twitter](https://twitter.com/tomkwong)
+* Will Kimmerer, Local Meetups [Twitter](https://twitter.com/KimmererWill)
 
 ## Proceedings Committee
 


### PR DESCRIPTION
So people know I'm posting somewhat officially related to meetup stuff.

Happy to be put elsewhere, but just want folks to know my meetup posts and advertisements come from committee not a random.