### PR TITLE
changed Paul Tiede website

### DIFF
--- a/2026/index.md
+++ b/2026/index.md
@@ -38,7 +38,7 @@ If you are an accepted speaker and require a travel funding, please fill out [th
 @@row,row-section
 \keynote{name="Julia Kowalski", affil="RWTH Aachen University", link="https://www.mbd.rwth-aachen.de/cms/mbd/Der-Lehrstuhl/Team/~qashd/Julia-Kowalski/lidx/1/", img="/assets/2026/img/keynotes/Julia_Kowalski.jpg", title=""}
 \keynote{name="Zoë Holmes", affil="EPFL", link="https://www.epfl.ch/labs/qic/prof-zoe-holmes/", img="/assets/2026/img/keynotes/Zoe_Holmes.png", title=""}
-\keynote{name="Paul Tiede", affil="Black Hole Initiative, Harvard University", link="https://www.cfa.harvard.edu/people/paul-tiede", img="/assets/2026/img/keynotes/Paul_Tiede.jpg", title=""}
+\keynote{name="Paul Tiede", affil="Black Hole Initiative, Harvard University", link="https://bhi.fas.harvard.edu/people/paul-tiede/", img="/assets/2026/img/keynotes/Paul_Tiede.jpg", title=""}
 \keynote{name="Simon Peyton Jones", affil="Engineering Fellow, Epic Games", link="https://simon.peytonjones.org", img="/assets/2026/img/keynotes/SimonPeytonJones.jpeg", title=""}
 <!-- \keynote{name="Julia Core Developers", affil="", link="https://julialang.org/", img="/assets/2026/img/keynotes/teamjuliacon_logo.png", title="State of Julia 2026"} -->
 @@


### PR DESCRIPTION
## Briefly Describe your changes

The old link does not work / directs to an "access denied" page
<img width="1006" height="604" alt="image" src="https://github.com/user-attachments/assets/988c84dc-5ee5-4f31-894a-e7283e399e44" />

The new link is the same as on the keynote page (which works).

https://github.com/JuliaCon/www.juliacon.org/blob/08dddbffc6bad2f12463e923b4a735d0a8acf62b/2026/keynotes.md?plain=1#L25

## Checklist for merge
- [ ] I built the website locally and tested it using `Franklin.serve()`
- [ ] All CI checks have passed and you have tested the online version (click on the list of checks and click `Build and Deploy / Preview` to see the preview)
- [ ] Somebody else reviewed my changes (use your best judgement if you need to merge quickly

## After merge
- [ ] Closed relevant issues
